### PR TITLE
fix(support): Put each button on new line (Closes #119)

### DIFF
--- a/e2e/dm.en.spec.ts
+++ b/e2e/dm.en.spec.ts
@@ -200,8 +200,8 @@ describe("[default language - english]", () => {
           statModel.langId,
           LabelId.SupportCommand,
           new TelegramMessageMeta(TelegramMessageMetaType.Link, [
-            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
             new TelegramMessageMetaItem(LabelId.ContactAuthor, authorUrl),
+            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
           ])
         ),
       ]);

--- a/e2e/dm.ru.spec.ts
+++ b/e2e/dm.ru.spec.ts
@@ -205,8 +205,8 @@ describe("[russian language]", () => {
           statModel.langId,
           LabelId.SupportCommand,
           new TelegramMessageMeta(TelegramMessageMetaType.Link, [
-            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
             new TelegramMessageMetaItem(LabelId.ContactAuthor, authorUrl),
+            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
           ])
         ),
       ]);

--- a/e2e/group.en.spec.ts
+++ b/e2e/group.en.spec.ts
@@ -235,8 +235,8 @@ describe("[default language - english]", () => {
           statModel.langId,
           LabelId.SupportCommand,
           new TelegramMessageMeta(TelegramMessageMetaType.Link, [
-            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
             new TelegramMessageMetaItem(LabelId.ContactAuthor, authorUrl),
+            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
           ])
         ),
       ]);
@@ -260,8 +260,8 @@ describe("[default language - english]", () => {
           statModel.langId,
           LabelId.SupportCommand,
           new TelegramMessageMeta(TelegramMessageMetaType.Link, [
-            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
             new TelegramMessageMetaItem(LabelId.ContactAuthor, authorUrl),
+            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
           ])
         ),
       ]);

--- a/e2e/group.ru.spec.ts
+++ b/e2e/group.ru.spec.ts
@@ -240,8 +240,8 @@ describe("[russian language]", () => {
           statModel.langId,
           LabelId.SupportCommand,
           new TelegramMessageMeta(TelegramMessageMetaType.Link, [
-            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
             new TelegramMessageMetaItem(LabelId.ContactAuthor, authorUrl),
+            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
           ])
         ),
       ]);
@@ -265,8 +265,8 @@ describe("[russian language]", () => {
           statModel.langId,
           LabelId.SupportCommand,
           new TelegramMessageMeta(TelegramMessageMetaType.Link, [
-            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
             new TelegramMessageMetaItem(LabelId.ContactAuthor, authorUrl),
+            new TelegramMessageMetaItem(LabelId.GithubIssues, githubUrl),
           ])
         ),
       ]);

--- a/src/telegram/actions/support.ts
+++ b/src/telegram/actions/support.ts
@@ -35,18 +35,19 @@ export class SupportAction extends GenericAction {
 
     return this.getChatLanguage(model, prefix)
       .then((lang) => {
-        const buttons: TgInlineKeyboardButton[] = [];
-        buttons.push({
+        const issueBtn: TgInlineKeyboardButton = {
           text: this.text.t(LabelId.GithubIssues, lang),
           url: githubUrl,
-        });
+        };
 
-        if (this.authorUrl) {
-          buttons.push({
-            text: this.text.t(LabelId.ContactAuthor, lang),
-            url: this.authorUrl,
-          });
-        }
+        const authorBtn: TgInlineKeyboardButton = {
+          text: this.text.t(LabelId.ContactAuthor, lang),
+          url: this.authorUrl,
+        };
+
+        const buttons: TgInlineKeyboardButton[][] = this.authorUrl
+          ? [[authorBtn], [issueBtn]]
+          : [[issueBtn]];
 
         return this.sendMessage(
           model.id,
@@ -54,7 +55,7 @@ export class SupportAction extends GenericAction {
           LabelId.SupportCommand,
           {
             lang,
-            options: [buttons],
+            options: buttons,
           },
           prefix
         );


### PR DESCRIPTION
There was a bug that we render buttons on the same line.
It cuts the label and does not help to provide any support.
This commit puts each button on the new line as in language selector