### PR TITLE
fix(): Downgrade wav buffer sample rate

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -9,3 +9,5 @@ export const kofiAccount = "https://ko-fi.com/audiomessbot";
 export const yandexAccount = "https://yasobe.ru/na/audiomessbot";
 
 export const officialChannelAccount = "https://t.me/AudioMessBotNews";
+
+export const wavSampleRate = 16_000; // 16kHz

--- a/src/env.ts
+++ b/src/env.ts
@@ -67,3 +67,5 @@ export const witAiApi = {
   tokenEn: process.env.WIT_AI_TOKEN_EN || "",
   tokenRu: process.env.WIT_AI_TOKEN_RU || "",
 };
+
+export const isDebug = process.env.DEBUG === "true";

--- a/src/ogg/index.ts
+++ b/src/ogg/index.ts
@@ -3,6 +3,8 @@ import { FFmpeg } from "prism-media";
 import { get as runGet } from "https";
 import { writeFile } from "fs";
 import { Logger } from "../logger";
+import { isDebug } from "../env";
+import { wavSampleRate as sampleRate } from "../const";
 
 const logger = new Logger("ogg-to-wav");
 
@@ -17,7 +19,7 @@ const getWavBuffer = (fileLink: string): Promise<Buffer> => {
       // WAV header here we go
       wavBuffer.push(
         generateHeader(0, {
-          sampleRate: 48000,
+          sampleRate,
         })
       );
 
@@ -38,7 +40,7 @@ const getMpegDecoder = (): FFmpeg =>
       "-f",
       "s16le",
       "-ar",
-      "48000",
+      String(sampleRate),
       "-ac",
       "1",
     ],
@@ -54,9 +56,9 @@ const saveBufferToFile = (buff: Buffer, fileName = "output.wav"): void => {
   });
 };
 
-export const getWav = (fileLink: string, debug = false): Promise<Buffer> => {
+export const getWav = (fileLink: string): Promise<Buffer> => {
   return getWavBuffer(fileLink).then((buff) => {
-    if (debug) {
+    if (isDebug) {
       saveBufferToFile(buff);
     }
 


### PR DESCRIPTION
For some reason, wit.ai changed the flow and now 48kHz wav audio
can not be processed properly. The Suggestion was to downgrade the
sample rate to 16kHz and it works now.

https://github.com/wit-ai/wit/issues/2153
https://github.com/wit-ai/wit/issues/2154