### PR TITLE
fix(): Downlevel no rights errors. Make it warn

### DIFF
--- a/src/telegram/api/index.ts
+++ b/src/telegram/api/index.ts
@@ -116,20 +116,18 @@ export class TelegramApi {
             new TgError(answer.description)
               .setUrl(url)
               .setErrorCode(answer.error_code)
-              .setRetryAfter(answer.parameters && answer.parameters.retry_after)
-              .setMigrateToChatId(
-                answer.parameters && answer.parameters.migrate_to_chat_id
-              )
+              .setRetryAfter(answer?.parameters?.retry_after)
+              .setMigrateToChatId(answer?.parameters?.migrate_to_chat_id)
           );
         }
 
         return answer.result;
       },
-      (err: AxiosError<string>) => {
+      (err: AxiosError<TgCore<void>>) => {
         throw new TgError(err.message, err.stack)
           .setUrl(url)
-          .setErrorCode(err.response && err.response.status)
-          .setResponse(err.response && err.response.data);
+          .setErrorCode(err?.response?.status)
+          .setResponse(err?.response?.data);
       }
     );
   }

--- a/src/telegram/api/tgapi.spec.ts
+++ b/src/telegram/api/tgapi.spec.ts
@@ -331,7 +331,7 @@ describe("[telegram api client]", () => {
           expect(err.message).toBe(`ETELEGRAM ${testErrorDescription}`);
           expect(err.code).toBe(testErrorCode);
           expect(err.url).toBe(`/bot${testApiToken}/setWebHook`);
-          expect(err.response).toBe("");
+          expect(err.response).toBe(undefined);
           expect(err.migrateToChatId).toBe(0);
           expect(err.retryAfter).toBe(0);
         });
@@ -376,7 +376,7 @@ describe("[telegram api client]", () => {
             expect(err.message).toBe(`ETELEGRAM ${testErrorDescription}`);
             expect(err.code).toBe(testErrorCode);
             expect(err.url).toBe(`/bot${testApiToken}/setMyCommands`);
-            expect(err.response).toBe("");
+            expect(err.response).toBe(undefined);
             expect(err.migrateToChatId).toBe(0);
             expect(err.retryAfter).toBe(testRetryAfter);
           }
@@ -406,7 +406,7 @@ describe("[telegram api client]", () => {
           );
           expect(err.code).toBe(testErrorCode);
           expect(err.url).toBe(`/bot${testApiToken}/getWebhookInfo`);
-          expect(err.response).toBe("");
+          expect(err.response).toBe(undefined);
           expect(err.migrateToChatId).toBe(0);
           expect(err.retryAfter).toBe(0);
         });
@@ -447,7 +447,7 @@ describe("[telegram api client]", () => {
             expect(err.message).toBe(`ETELEGRAM ${testErrorDescription}`);
             expect(err.code).toBe(testErrorCode);
             expect(err.url).toBe(`/bot${testApiToken}/getFile`);
-            expect(err.response).toBe("");
+            expect(err.response).toBe(undefined);
             expect(err.migrateToChatId).toBe(testMigrateToChat);
             expect(err.retryAfter).toBe(testRetryAfter);
           }
@@ -515,7 +515,7 @@ describe("[telegram api client]", () => {
         expect(err.message).toBe(`ETELEGRAM ${testErrMsg}`);
         expect(err.code).toBe(0);
         expect(err.url).toBe(`/bot${testApiToken}/editMessageText`);
-        expect(err.response).toBe("");
+        expect(err.response).toBe(undefined);
         expect(err.migrateToChatId).toBe(0);
         expect(err.retryAfter).toBe(0);
       });

--- a/src/telegram/api/types.ts
+++ b/src/telegram/api/types.ts
@@ -119,7 +119,7 @@ export interface TgFile {
 
 export class TgError extends Error {
   public code = 0;
-  public response = "";
+  public response?: TgCore<void>;
   public migrateToChatId = 0;
   public retryAfter = 0;
   public url = "";
@@ -136,7 +136,7 @@ export class TgError extends Error {
     return this;
   }
 
-  public setResponse(response = ""): this {
+  public setResponse(response?: TgCore<void>): this {
     this.response = response;
     return this;
   }

--- a/src/telegram/errors.ts
+++ b/src/telegram/errors.ts
@@ -1,0 +1,13 @@
+import { TgError } from "./api/types";
+
+export const hasNoRightsToSendMessage = (err: unknown): boolean => {
+  if (err instanceof TgError) {
+    const isErr = !err?.response?.ok;
+    const isBadRequest = err?.response?.error_code === 400;
+    const hasNoRights =
+      err?.response?.description?.toLowerCase() ===
+      "Bad Request: have no rights to send a message".toLowerCase();
+    return isErr && isBadRequest && hasNoRights;
+  }
+  return false;
+};


### PR DESCRIPTION
If the group disable bot ability to send messages, we
will face the HTTP 400 from the Telegram api. We rather
keep trying but make the logged error a warning