### PR TITLE
fix(WitAi): Add extra logs to check the error

### DIFF
--- a/src/recognition/wit.ai.ts
+++ b/src/recognition/wit.ai.ts
@@ -101,9 +101,13 @@ export class WithAiProvider extends VoiceConverter {
           ({ is_final: isFinal }) => isFinal
         );
         if (!finalizedChunks.length) {
-          throw new Error(
-            "The final response chunk not found. Transcription is empty."
+          const errMessage =
+            "The final response chunk not found. Transcription is empty.";
+          logger.warn(
+            errMessage,
+            chunks.map(({ text }) => text)
           );
+          throw new Error(errMessage);
         }
         return finalizedChunks;
       });


### PR DESCRIPTION
In order to track down and find a workaround for
`The final response chunk not found` error, we
add more logs and see the received chunks