### PR TITLE
fix(WitAi): No final chunk means empty response

### DIFF
--- a/src/recognition/wit.ai.ts
+++ b/src/recognition/wit.ai.ts
@@ -101,13 +101,10 @@ export class WithAiProvider extends VoiceConverter {
           ({ is_final: isFinal }) => isFinal
         );
         if (!finalizedChunks.length) {
-          const errMessage =
-            "The final response chunk not found. Transcription is empty.";
           logger.warn(
-            errMessage,
+            "The final response chunk not found. Transcription is empty.",
             chunks.map(({ text }) => text)
           );
-          throw new Error(errMessage);
         }
         return finalizedChunks;
       });


### PR DESCRIPTION
There is an edge case when the api response do not
have the chunk that marked as is_final. In this case
we used to say "there was an error during the voice
recognition". Technically it is not an error, so we
rather tell users it was an empty recognition. This
should not appear as an alert in the Loggly logs