### PR TITLE
feat(threads): Support Forum groups

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -227,3 +227,17 @@ of capacity to extend the functionality at the moment. But what I do is I keep t
 working (which is important) and also trying to get the opportunities when something is
 happening around. I love these news that I can enable longer voice messages to be transformed
 into text. Who knows what is next?
+
+### Forum groups support
+
+Recently Telegram introduced a concept of forum (or thread) groups. You can turn your group into
+the list of threads, each thread represents a channel on its own. For Forum groups Telegram
+introduced more metadata in the Message object. Now we have isTopicMessage flag that shows if we
+are in such thread group. And also messageThreadId is the anchor for the particular thread in the
+group. To support this we need to supply API payload with the threadId every time we want to answer
+in the thread. I usually barely follow the API documentation updates and found the related exception
+thanks to logs! Fo those who are (like me) did not have a clue what is changed, you might find
+yourself catching the errors like "Bad Request: TOPIC_DELETED" which is a clear indicator someone
+tries to use the bot in the forum group, but without the messageThreadId identifier Telegram fails
+to distinguish the particular thread to answer.
+We also celebrate 38000+ installs and 1000+ weekly active users! Omg this escalates quickly.

--- a/src/db/nodes.spec.ts
+++ b/src/db/nodes.spec.ts
@@ -224,7 +224,7 @@ describe("Nodes DB", () => {
 
       testPool.mockQuery(NodesSql.updateRow, (values) => {
         expect(values).toHaveLength(4);
-        const [rActive, rVersion, _rUpdated, rNodeId] = values;
+        const [rActive, rVersion, , rNodeId] = values;
 
         expect(rNodeId).toBe(nodeId);
         expect(rActive).toBe(active);

--- a/src/db/usages.spec.ts
+++ b/src/db/usages.spec.ts
@@ -631,7 +631,7 @@ describe("Usages DB", () => {
         );
         testPool.mockQuery(UsagesSql.updateRow, (values) => {
           expect(values).toHaveLength(5);
-          const [rUser, rUsageCount, rLangId, _rUpdated, rUsageId] = values;
+          const [rUser, rUsageCount, rLangId, , rUsageId] = values;
 
           expect(rUsageId).toBe(usageId);
           expect(rUser).toBe(userName);

--- a/src/recognition/aws.ts
+++ b/src/recognition/aws.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { LanguageCode, VoiceConverter, VoiceConverterOptions } from "./types";
+import { VoiceConverter, VoiceConverterOptions } from "./types";
 import { getWav } from "../ffmpeg";
 import { Logger } from "../logger";
 
@@ -32,8 +32,7 @@ export class AWSProvider extends VoiceConverter {
   public transformToText(
     fileLink: string,
     fileId: string,
-    isVideo: boolean,
-    lang: LanguageCode
+    isVideo: boolean
   ): Promise<string> {
     const name = `${fileId}.ogg`;
     logger.info(`Starting process for ${Logger.y(name)}`);

--- a/src/telegram/actions/common.ts
+++ b/src/telegram/actions/common.ts
@@ -54,7 +54,8 @@ export abstract class GenericAction {
     chatId: number,
     ids: LabelId | LabelId[],
     meta: MessageOptions,
-    prefix: TelegramMessagePrefix
+    prefix: TelegramMessagePrefix,
+    forumThreadId?: number
   ): Promise<void> {
     const msgs = Array.isArray(ids) ? ids : [ids];
     if (!msgs.length) {
@@ -67,10 +68,17 @@ export abstract class GenericAction {
     }
 
     logger.info(`${prefix.getPrefix()} Sending the message`);
-    return this.sendRawMessage(chatId, this.text.t(part, meta.lang), {
-      buttons: meta.options,
-    })
-      .then(() => this.sendMessage(messageId, chatId, msgs, meta, prefix))
+    return this.sendRawMessage(
+      chatId,
+      this.text.t(part, meta.lang),
+      {
+        buttons: meta.options,
+      },
+      forumThreadId
+    )
+      .then(() =>
+        this.sendMessage(messageId, chatId, msgs, meta, prefix, forumThreadId)
+      )
       .catch((err) => {
         logger.error(`${prefix.getPrefix()} Unable to send the message`, err);
         throw err;
@@ -101,9 +109,12 @@ export abstract class GenericAction {
     options: {
       buttons?: TgInlineKeyboardButton[][];
       disableMarkup?: boolean;
-    } = {}
+    } = {},
+    forumThreadId?: number
   ): Promise<void> {
-    return this.bot.sendMessage(chatId, message, options).then(flattenPromise);
+    return this.bot
+      .sendMessage(chatId, message, options, forumThreadId)
+      .then(flattenPromise);
   }
 }
 

--- a/src/telegram/actions/fund.ts
+++ b/src/telegram/actions/fund.ts
@@ -76,7 +76,8 @@ export class FundAction extends GenericAction {
             lang,
             options: buttons,
           },
-          prefix
+          prefix,
+          model.forumThreadId
         );
       })
       .then(() => logger.info(`${prefix.getPrefix()} Fund message sent`))
@@ -146,7 +147,8 @@ export class FundAction extends GenericAction {
           donationId,
           token,
           lang,
-          prefix
+          prefix,
+          model.forumThreadId
         );
       })
       .catch((err) => {
@@ -194,7 +196,8 @@ export class FundAction extends GenericAction {
     donationId: number,
     token: string,
     lang: LanguageCode,
-    prefix: TelegramMessagePrefix
+    prefix: TelegramMessagePrefix,
+    forumThreadId?: number
   ): Promise<void> {
     const title = this.text.t(LabelId.DonationTitle, lang);
     const description = this.text.t(LabelId.DonationDescription, lang);
@@ -214,7 +217,8 @@ export class FundAction extends GenericAction {
         description,
         label,
         getDonationDtoString(donationId, chatId, prefix.id),
-        photo
+        photo,
+        forumThreadId
       )
       .then(() => logger.info(`${prefix.getPrefix()} Invoice sent`))
       .catch((err) => {

--- a/src/telegram/actions/lang.ts
+++ b/src/telegram/actions/lang.ts
@@ -54,10 +54,16 @@ export class LangAction extends GenericAction {
   ): Promise<void> {
     const messageId = message.message_id;
     const chatId = message.chat.id;
+    let forumThreadId: number | undefined;
+    if (message.is_topic_message && message.message_thread_id) {
+      forumThreadId = message.message_thread_id;
+    }
     analytics.setId(chatId).setLang(getRawUserLanguage(msg));
 
     return this.getLangData(chatId, button)
-      .then((opts) => this.updateLanguage(opts, chatId, messageId, analytics))
+      .then((opts) =>
+        this.updateLanguage(opts, chatId, messageId, analytics, forumThreadId)
+      )
       .catch((err) => {
         const errorMessage = "Unable to handle language change";
         logger.error(errorMessage, err);
@@ -78,7 +84,8 @@ export class LangAction extends GenericAction {
     opts: BotLangData,
     chatId: number,
     messageId: number,
-    analytics: AnalyticsData
+    analytics: AnalyticsData,
+    forumThreadId?: number
   ): Promise<void> {
     const lang = opts.langId;
     const prefix = opts.prefix;
@@ -100,7 +107,8 @@ export class LangAction extends GenericAction {
             chatId,
             LabelId.UpdateLanguageError,
             { lang },
-            prefix
+            prefix,
+            forumThreadId
           );
         }
       )
@@ -187,7 +195,8 @@ export class LangAction extends GenericAction {
               ],
             ],
           },
-          prefix
+          prefix,
+          model.forumThreadId
         );
       })
       .then(() => logger.info(`${prefix.getPrefix()} Language selector sent`))

--- a/src/telegram/actions/start.ts
+++ b/src/telegram/actions/start.ts
@@ -40,7 +40,8 @@ export class StartAction extends GenericAction {
             LabelId.DonateMessage,
           ],
           { lang },
-          prefix
+          prefix,
+          model.forumThreadId
         )
       )
       .then(() => logger.info(`${prefix.getPrefix()} Hello message sent`))

--- a/src/telegram/actions/support.ts
+++ b/src/telegram/actions/support.ts
@@ -64,7 +64,8 @@ export class SupportAction extends GenericAction {
             lang,
             options: buttons,
           },
-          prefix
+          prefix,
+          model.forumThreadId
         );
       })
       .then(() => logger.info(`${prefix.getPrefix()} Support message sent`))

--- a/src/telegram/actions/voice-format.ts
+++ b/src/telegram/actions/voice-format.ts
@@ -64,7 +64,8 @@ export class VoiceFormatAction extends GenericAction {
           {
             lang,
           },
-          prefix
+          prefix,
+          model.forumThreadId
         )
       )
       .then(() =>

--- a/src/telegram/actions/voice-length.ts
+++ b/src/telegram/actions/voice-length.ts
@@ -60,7 +60,8 @@ export class VoiceLengthAction extends GenericAction {
           {
             lang,
           },
-          prefix
+          prefix,
+          model.forumThreadId
         )
       )
       .then(() =>

--- a/src/telegram/actions/voice.ts
+++ b/src/telegram/actions/voice.ts
@@ -11,7 +11,7 @@ import { LabelId } from "../../text/labels";
 import { LanguageCode, VoiceConverter } from "../../recognition/types";
 import { collectAnalytics, collectPageAnalytics } from "../../analytics";
 import { TimeMeasure } from "../../common/timer";
-import { hasNoRightsToSendMessage } from "../errors";
+import { hasNoRightsToSendMessage, isBlockedByUser } from "../errors";
 
 const logger = new Logger("telegram-bot");
 
@@ -108,11 +108,12 @@ export class VoiceAction extends GenericAction {
       })
       .catch((err) => {
         const hasNoRights = hasNoRightsToSendMessage(err);
+        const isBlocked = isBlockedByUser(err);
         const errorMessage = "Unable to recognize the file";
         const logError = `${prefix.getPrefix()} ${errorMessage} ${Logger.y(
           model.voiceFileId
         )}`;
-        if (hasNoRights) {
+        if (hasNoRights || isBlocked) {
           logger.warn(logError, err);
         } else {
           logger.error(logError, err);

--- a/src/telegram/actions/voice.ts
+++ b/src/telegram/actions/voice.ts
@@ -91,16 +91,22 @@ export class VoiceAction extends GenericAction {
             {
               lang,
             },
-            prefix
+            prefix,
+            model.forumThreadId
           );
         }
 
         model.analytics.v4.addTime("voice-to-text-time", time.getMs());
         const name = model.fullUserName || model.userName;
         const msgPrefix = model.isGroup && name ? `${name} ` : "";
-        return this.sendRawMessage(model.chatId, `${msgPrefix}🗣 ${text}`, {
-          disableMarkup: true,
-        });
+        return this.sendRawMessage(
+          model.chatId,
+          `${msgPrefix}🗣 ${text}`,
+          {
+            disableMarkup: true,
+          },
+          model.forumThreadId
+        );
       })
       .then(() => {
         logger.info(`${prefix.getPrefix()} Voice successfully converted`);
@@ -132,7 +138,8 @@ export class VoiceAction extends GenericAction {
           {
             lang,
           },
-          prefix
+          prefix,
+          model.forumThreadId
         );
       })
       .catch((err) => {
@@ -179,7 +186,8 @@ export class VoiceAction extends GenericAction {
       {
         lang,
       },
-      prefix
+      prefix,
+      model.forumThreadId
     ).catch((err) => {
       const errorMessage = "Unable to send in progress message";
       logger.error(`${prefix.getPrefix()} ${errorMessage}`, err);

--- a/src/telegram/api/index.ts
+++ b/src/telegram/api/index.ts
@@ -71,12 +71,17 @@ export class TelegramApi {
     options: {
       buttons?: TgInlineKeyboardButton[][];
       disableMarkup?: boolean;
-    } = {}
+    } = {},
+    forumThreadId?: number
   ): Promise<TgMessage> {
     const data: MessageDto = {
       text,
       chat_id: chatId,
     };
+
+    if (forumThreadId) {
+      data.message_thread_id = forumThreadId;
+    }
 
     if (!options.disableMarkup) {
       data.parse_mode = "HTML";
@@ -147,7 +152,8 @@ export class TelegramApi {
       url: string;
       height: number;
       width: number;
-    }
+    },
+    forumThreadId?: number
   ): Promise<TgMessage> {
     const data: InvoiceDto = {
       chat_id: chatId,
@@ -167,6 +173,10 @@ export class TelegramApi {
       photo_width: photo.width,
       photo_height: photo.height,
     };
+
+    if (forumThreadId) {
+      data.message_thread_id = forumThreadId;
+    }
 
     return this.request<TgMessage, InvoiceDto>("sendInvoice", data);
   }

--- a/src/telegram/api/types.ts
+++ b/src/telegram/api/types.ts
@@ -38,6 +38,8 @@ export interface TgMessage {
   audio?: TgMedia;
   video_note?: TgMedia;
   successful_payment?: SuccessfulPayment;
+  is_topic_message?: boolean;
+  message_thread_id?: number;
 }
 
 export interface TgChat {
@@ -117,6 +119,7 @@ export interface MessageDto {
   reply_markup?: {
     inline_keyboard: TgInlineKeyboardButton[][];
   };
+  message_thread_id?: number;
 }
 
 interface LabeledPrice {
@@ -132,10 +135,11 @@ export interface InvoiceDto {
   provider_token: string; // Provider token
   currency: string; // EUR
   prices: LabeledPrice[];
-  start_parameter: string; // donation id
+  start_parameter: string; // Donation id
   photo_url: string;
   photo_width: number;
   photo_height: number;
+  message_thread_id?: number; // Forum thread id
 }
 
 export interface PreCheckoutQueryDto {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -201,7 +201,8 @@ export class TelegramBotModel {
           model.chatId,
           LabelId.NoContent,
           { lang },
-          prefix
+          prefix,
+          model.forumThreadId
         )
       )
       .catch((err) => {

--- a/src/telegram/errors.ts
+++ b/src/telegram/errors.ts
@@ -11,3 +11,15 @@ export const hasNoRightsToSendMessage = (err: unknown): boolean => {
   }
   return false;
 };
+
+export const isBlockedByUser = (err: unknown): boolean => {
+  if (err instanceof TgError) {
+    const isErr = !err?.response?.ok;
+    const isForbidden = err?.response?.error_code === 403;
+    const isBlocked =
+      err?.response?.description?.toLowerCase() ===
+      "Forbidden: bot was blocked by the user".toLowerCase();
+    return isErr && isForbidden && isBlocked;
+  }
+  return false;
+};

--- a/src/telegram/types.ts
+++ b/src/telegram/types.ts
@@ -54,6 +54,7 @@ export class BotMessageModel {
   public readonly userLanguage: LanguageCode;
   public readonly analytics: AnalyticsData;
   public readonly donationId: number;
+  public readonly forumThreadId?: number;
 
   constructor(msg: TgMessage, analytics: AnalyticsData) {
     this.id = msg.message_id;
@@ -69,6 +70,9 @@ export class BotMessageModel {
     this.donationId = parseDonationPayload(
       msg.successful_payment?.invoice_payload
     ).donationId;
+    if (msg.is_topic_message && msg.message_thread_id) {
+      this.forumThreadId = msg.message_thread_id;
+    }
     this.analytics = analytics
       .setId(this.chatId)
       .setLang(getRawUserLanguage(msg));


### PR DESCRIPTION
For Forum groups Telegram introduced more metadata in the Message object. Now we have
isTopicMessage flag that shows if we are in the thread group.
and also MessageThreadId is the anchor for the particular
thread in the group. To support this we need to
put the threadId into api payload every time we
want to answer in the thread, hence this change