### PR TITLE
fix(telegram): Send huge message in chunks (Closes #267)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -241,3 +241,14 @@ yourself catching the errors like "Bad Request: TOPIC_DELETED" which is a clear 
 tries to use the bot in the forum group, but without the messageThreadId identifier Telegram fails
 to distinguish the particular thread to answer.
 We also celebrate 38000+ installs and 1000+ weekly active users! Omg this escalates quickly.
+
+### Telegram message max length is 4096 chars
+
+You could expect the messages in the social media platform have the length limit. Thi sis also true
+for Telegram. It has the 4096 chars limit for a single message content. Why care? Back in the days
+the voice message length was limited by 20 seconds, which is rather small. In the meantime, it means
+we can never hit the text limit per message. Now we have a voice duration limit equal to 1,5 minutes!
+It is still not that long, but I was able to catch the error in the logs that some message hit the
+limit. With this commit, it should be fixed. We now split messages longer than 4096 characters into
+chunks and send each chunk separately one by one.
+As for the metrics, we went beyond 40000+ installs and floating around the 1200 WAU.

--- a/src/common/helpers.spec.ts
+++ b/src/common/helpers.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "@jest/globals";
+import { splitTextIntoParts } from "./helpers";
+import { LanguageCode } from "../recognition/types";
+
+describe("common helpers", () => {
+  describe("splitTextIntoParts", () => {
+    it("should return the array of the same text if it is less than the max size", () => {
+      const text = "one two three";
+      const maxLength = text.length + 1;
+      expect(splitTextIntoParts(text, LanguageCode.En, maxLength)).toEqual([
+        text,
+      ]);
+    });
+
+    it("should return the array of the same text if it is equal to the max size", () => {
+      const text = "one two three";
+      const maxLength = text.length;
+      expect(splitTextIntoParts(text, LanguageCode.En, maxLength)).toEqual([
+        text,
+      ]);
+    });
+
+    it("should return the parts of the text if the text is longer than max size", () => {
+      const text = "one two three";
+      const maxLength = 7;
+      expect(splitTextIntoParts(text, LanguageCode.En, maxLength)).toEqual([
+        "one two",
+        "three",
+      ]);
+    });
+
+    it("should not return the trailing whitespace in the last part", () => {
+      const text = "one two three ";
+      const maxLength = text.length - 1;
+      expect(splitTextIntoParts(text, LanguageCode.En, maxLength)).toEqual([
+        "one two three",
+      ]);
+    });
+  });
+});

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -1,5 +1,6 @@
 import { Logger } from "../logger";
 import { sleepFor } from "./timer";
+import { LanguageCode } from "../recognition/types";
 
 const logger = new Logger("run-retry");
 
@@ -29,4 +30,35 @@ export const runPromiseWithRetry = <D>(
 
 export const flattenPromise = () => {
   // Flatten promise
+};
+
+export const splitTextIntoParts = (
+  text: string,
+  lang: LanguageCode,
+  maxLength: number
+): string[] => {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+
+  const segmenter = new Intl.Segmenter(lang, { granularity: "word" });
+  const segments = segmenter.segment(text);
+
+  const parts: string[] = [];
+
+  let part = "";
+  for (const { segment } of segments) {
+    if (part.length + segment.length > maxLength) {
+      parts.push(part.trim());
+      part = "";
+    }
+    part = `${part}${segment}`;
+  }
+
+  part = part.trim();
+  if (part) {
+    parts.push(part);
+  }
+
+  return parts;
 };

--- a/src/telegram/actions/voice.ts
+++ b/src/telegram/actions/voice.ts
@@ -102,6 +102,7 @@ export class VoiceAction extends GenericAction {
         return this.sendRawMessage(
           model.chatId,
           `${msgPrefix}🗣 ${text}`,
+          lang,
           {
             disableMarkup: true,
           },

--- a/src/telegram/api/index.ts
+++ b/src/telegram/api/index.ts
@@ -15,6 +15,8 @@ import {
   TgWebHook,
 } from "./types";
 
+export const TELEGRAM_API_MAX_MESSAGE_SIZE = 4096;
+
 export class TelegramApi {
   public static readonly url = "https://api.telegram.org";
   public static readonly timeout = 60_000;


### PR DESCRIPTION
Split huge text messages into chunk 4096 chars each (telegram message limit), hence prepare the application for a longer voice messages