### PR TITLE
fix(docker): Add monitoring agent in the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,14 @@
-node_modules
 .git
+.github
+.husky
 .idea
-e2e
-k8s
 assets
 coverage-e2e
 coverage-unit
+e2e
+k8s
+node_modules
+spmdb
+spmlogs
+HISTORY.md
 /**/*/*.spec.ts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,42 +73,42 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
           D_NAME: ${{ secrets.HEROKU_APP_MASTER }}
 
-  heroku-secondary:
-    runs-on: ubuntu-latest
-    name: Deploy to Heroku Secondary account
-    needs: heroku-primary
-    steps:
-      - name: App version
-        run: echo "Picked the app version ${GITHUB_SHA}"
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup NodeJS using the obtained nvm version
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Login to Heroku Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: registry.heroku.com
-          username: ${{ secrets.HEROKU_EMAIL }}
-          password: ${{ secrets.HEROKU_API_KEY }}
-
-      - name: Push docker image
-        run: heroku container:push web --app ${{ env.D_NAME }} --arg APP_VERSION=${{ env.D_VERSION }} --arg=${{ env.D_INFRA_TOKEN }}
-        env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-          D_NAME: ${{ secrets.HEROKU_APP_SLAVE }}
-          D_VERSION: ${{ github.sha }}
-          D_INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
-
-      - name: Release docker image
-        run: heroku container:release web --app ${{ env.D_NAME }}
-        env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-          D_NAME: ${{ secrets.HEROKU_APP_SLAVE }}
+  #  heroku-secondary:
+  #    runs-on: ubuntu-latest
+  #    name: Deploy to Heroku Secondary account
+  #    needs: heroku-primary
+  #    steps:
+  #      - name: App version
+  #        run: echo "Picked the app version ${GITHUB_SHA}"
+  #
+  #      - name: Checkout
+  #        uses: actions/checkout@v3
+  #
+  #      - name: Setup NodeJS using the obtained nvm version
+  #        uses: actions/setup-node@v3
+  #        with:
+  #          node-version-file: ".nvmrc"
+  #
+  #      - name: Login to Heroku Container Registry
+  #        uses: docker/login-action@v2
+  #        with:
+  #          registry: registry.heroku.com
+  #          username: ${{ secrets.HEROKU_EMAIL }}
+  #          password: ${{ secrets.HEROKU_API_KEY }}
+  #
+  #      - name: Push docker image
+  #        run: heroku container:push web --app ${{ env.D_NAME }} --arg APP_VERSION=${{ env.D_VERSION }} --arg=${{ env.D_INFRA_TOKEN }}
+  #        env:
+  #          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  #          D_NAME: ${{ secrets.HEROKU_APP_SLAVE }}
+  #          D_VERSION: ${{ github.sha }}
+  #          D_INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
+  #
+  #      - name: Release docker image
+  #        run: heroku container:release web --app ${{ env.D_NAME }}
+  #        env:
+  #          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  #          D_NAME: ${{ secrets.HEROKU_APP_SLAVE }}
 
   production:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           tags: |
             ghcr.io/${{ secrets.DOCKER_USERNAME }}/voice-to-text-bot/voice-to-speech-app:latest
             ghcr.io/${{ secrets.DOCKER_USERNAME }}/voice-to-text-bot/voice-to-speech-app:${{ github.sha }}
-          build-args: APP_VERSION=${{ github.sha }}
+          build-args: APP_VERSION=${{ github.sha }},INFRA_TOKEN=${{ secrets.INFRA_TOKEN }}
 
   heroku-primary:
     runs-on: ubuntu-latest
@@ -52,26 +52,25 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Docker login
-        run: echo ${{ env.D_PWD }} | docker login --username=${{ env.D_LOGIN }} ${{ env.D_REGISTRY }} --password-stdin
-        env:
-          D_LOGIN: ${{ secrets.HEROKU_EMAIL }}
-          D_PWD: ${{ secrets.HEROKU_API_KEY }}
-          D_REGISTRY: registry.heroku.com
+      - name: Login to Heroku Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: registry.heroku.com
+          username: ${{ secrets.HEROKU_EMAIL }}
+          password: ${{ secrets.HEROKU_API_KEY }}
 
       - name: Push docker image
-        run: heroku container:${{ env.D_ACTION }} web --app ${{ env.D_NAME }} --arg APP_VERSION=${{ env.D_VERSION }}
+        run: heroku container:push web --app ${{ env.D_NAME }} --arg APP_VERSION=${{ env.D_VERSION }} --arg=${{ env.D_INFRA_TOKEN }}
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-          D_ACTION: push
           D_NAME: ${{ secrets.HEROKU_APP_MASTER }}
           D_VERSION: ${{ github.sha }}
+          D_INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
 
       - name: Release docker image
-        run: heroku container:${{ env.D_ACTION }} web --app ${{ env.D_NAME }}
+        run: heroku container:release web --app ${{ env.D_NAME }}
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-          D_ACTION: release
           D_NAME: ${{ secrets.HEROKU_APP_MASTER }}
 
   heroku-secondary:
@@ -90,26 +89,25 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Docker login
-        run: echo ${{ env.D_PWD }} | docker login --username=${{ env.D_LOGIN }} ${{ env.D_REGISTRY }} --password-stdin
-        env:
-          D_LOGIN: ${{ secrets.HEROKU_EMAIL }}
-          D_PWD: ${{ secrets.HEROKU_API_KEY }}
-          D_REGISTRY: registry.heroku.com
+      - name: Login to Heroku Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: registry.heroku.com
+          username: ${{ secrets.HEROKU_EMAIL }}
+          password: ${{ secrets.HEROKU_API_KEY }}
 
       - name: Push docker image
-        run: heroku container:${{ env.D_ACTION }} web --app ${{ env.D_NAME }} --arg APP_VERSION=${{ env.D_VERSION }}
+        run: heroku container:push web --app ${{ env.D_NAME }} --arg APP_VERSION=${{ env.D_VERSION }} --arg=${{ env.D_INFRA_TOKEN }}
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-          D_ACTION: push
           D_NAME: ${{ secrets.HEROKU_APP_SLAVE }}
           D_VERSION: ${{ github.sha }}
+          D_INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
 
       - name: Release docker image
-        run: heroku container:${{ env.D_ACTION }} web --app ${{ env.D_NAME }}
+        run: heroku container:release web --app ${{ env.D_NAME }}
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-          D_ACTION: release
           D_NAME: ${{ secrets.HEROKU_APP_SLAVE }}
 
   production:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,30 @@ FROM node:16.16.0
 
 EXPOSE 8080
 
+ARG INFRA_TOKEN
+ARG INFRA_REGION=EU
+ARG APP_VERSION=local
+ENV APP_VERSION ${APP_VERSION}
+
+RUN echo ${APP_VERSION}
+
+# Launch monitoring agent
+RUN echo "deb http://pub-repo.sematext.com/ubuntu sematext main" | tee /etc/apt/sources.list.d/sematext.list > /dev/null
+RUN wget -O - https://pub-repo.sematext.com/ubuntu/sematext.gpg.key | apt-key add -
+RUN apt-get update
+
+RUN apt-get install -y openjdk-11-jdk ca-certificates-java
+RUN apt-get clean
+RUN update-ca-certificates -f
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
+RUN export JAVA_HOME
+
+RUN apt-get -y install sematext-agent
+
+RUN bash /opt/spm/bin/setup-infra --infra-token ${INFRA_TOKEN} --region ${INFRA_REGION}
+
+# Build and run the applicaiton
 ENV NODE_ENV production
 
 ARG APP_DIR=/usr/src/app/
@@ -14,11 +38,6 @@ RUN npm set-script prepare ""
 RUN npm ci --omit=dev && npm cache clean --force
 
 COPY . $APP_DIR
-
-ARG APP_VERSION=local
-ENV APP_VERSION ${APP_VERSION}
-
-RUN echo ${APP_VERSION}
 
 RUN npm run build
 


### PR DESCRIPTION
Right now the monitoring dashboard does not show many OS
related metrics. Most likely because we should run the
monitoring agent inside the docker image. This commit
aims to add the monitoring agent in the docker image