### PR TITLE
fix(logs): Sanitize request data (Closes #295)

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -35,7 +35,7 @@ jobs:
     name: Run validations
     strategy:
       matrix:
-        command: [typecheck, "lint:all"]
+        command: [typecheck, "lint:all", "format:check"]
     env:
       COMMAND: ${{ matrix.command }}
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,4 @@ package-lock.json
 .eslintignore
 dist/
 assets/
-coverage-e2e/
-coverage-unit/
+coverage/

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:js": "node -r ./init.cjs --experimental-loader newrelic/esm-loader.mjs dist/src/scripts/run.js dev js",
     "cluster:js": "node -r ./init.cjs --experimental-loader newrelic/esm-loader.mjs dist/src/scripts/run.js cluster js",
     "format": "prettier --write",
+    "format:check": "prettier --check .",
     "lint": "eslint",
     "lint:all": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/src/logger/integration.ts
+++ b/src/logger/integration.ts
@@ -79,8 +79,14 @@ const sanitizeError = (rawData: unknown): unknown => {
   // Axios .toJSON() returns object, not AxiosError :sad:
   const data = rawData.toJSON() as AxiosError;
 
+  // Sanitize the authorization token to keep secrets safe
   if (data?.config?.headers?.Authorization) {
     data.config.headers.Authorization = SANITIZE_CHARACTER;
+  }
+
+  // Sanitize the incoming buffer to keep user data safe and the log small
+  if (data.config?.data) {
+    data.config.data = SANITIZE_CHARACTER;
   }
 
   return data;


### PR DESCRIPTION
Logger can not parse long payloads and also this is kind of user input data. We want to play safe card and sanitize all the secrets and user payload from the logs