### PR TITLE
fix(logs): Wrap witai response, try reserializing

### DIFF
--- a/src/recognition/witai/wit.ai.error.spec.ts
+++ b/src/recognition/witai/wit.ai.error.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "@jest/globals";
+import { WitAiError } from "./wit.ai.error.js";
+
+describe("WitAiError", () => {
+  it("should construct the WitAi error wrapper", () => {
+    const errCause = new Error("original error");
+    const msg = "ooops";
+    const err = new WitAiError(msg, errCause);
+    expect(err.cause).toBe(errCause);
+    expect(err.message).toBe(`EWITAI ${msg}`);
+    expect(err.code).toBe(0);
+    expect(err.response).toBe(undefined);
+    expect(err.url).toBe("");
+    expect(err.bufferLength).toBe(-1);
+  });
+
+  it("should set the error code", () => {
+    const errCause = new Error("original error");
+    const msg = "ooops";
+    const err = new WitAiError(msg, errCause);
+    err.setErrorCode(400);
+    expect(err.cause).toBe(errCause);
+    expect(err.message).toBe(`EWITAI ${msg}`);
+    expect(err.code).toBe(400);
+    expect(err.response).toBe(undefined);
+    expect(err.url).toBe("");
+    expect(err.bufferLength).toBe(-1);
+  });
+
+  it("should set the url", () => {
+    const errCause = new Error("original error");
+    const msg = "ooops";
+    const err = new WitAiError(msg, errCause);
+    const url = "https://google.com";
+    err.setUrl(url);
+    expect(err.cause).toBe(errCause);
+    expect(err.message).toBe(`EWITAI ${msg}`);
+    expect(err.code).toBe(0);
+    expect(err.response).toBe(undefined);
+    expect(err.url).toBe(url);
+    expect(err.bufferLength).toBe(-1);
+  });
+
+  it("should set the buffer length", () => {
+    const errCause = new Error("original error");
+    const msg = "ooops";
+    const err = new WitAiError(msg, errCause);
+    const bufferMessage = "hello";
+    const buff = new Buffer(bufferMessage);
+    err.setBufferLength(buff);
+    expect(err.cause).toBe(errCause);
+    expect(err.message).toBe(`EWITAI ${msg}`);
+    expect(err.code).toBe(0);
+    expect(err.response).toBe(undefined);
+    expect(err.url).toBe("");
+    expect(err.bufferLength).toBe(bufferMessage.length);
+  });
+
+  it.each([
+    ["object", { foo: "bar" }],
+    ["array", [1]],
+    ["number", 191],
+    ["boolean", true],
+    ["non-serialized string", "foo-bar {}"],
+  ])("should set the non-string response (%s)", (_, response) => {
+    const errCause = new Error("original error");
+    const msg = "ooops";
+    const err = new WitAiError(msg, errCause);
+    err.setResponse(response);
+    expect(err.cause).toBe(errCause);
+    expect(err.message).toBe(`EWITAI ${msg}`);
+    expect(err.code).toBe(0);
+    expect(err.response).toEqual({ message: response });
+    expect(err.url).toBe("");
+    expect(err.bufferLength).toBe(-1);
+  });
+
+  it("should set the serialized response", () => {
+    const errCause = new Error("original error");
+    const msg = "ooops";
+    const err = new WitAiError(msg, errCause);
+    const response = { foo: "bar" };
+    err.setResponse(JSON.stringify(response));
+    expect(err.cause).toBe(errCause);
+    expect(err.message).toBe(`EWITAI ${msg}`);
+    expect(err.code).toBe(0);
+    expect(err.response).toEqual(response);
+    expect(err.url).toBe("");
+    expect(err.bufferLength).toBe(-1);
+  });
+});

--- a/src/recognition/witai/wit.ai.error.ts
+++ b/src/recognition/witai/wit.ai.error.ts
@@ -2,6 +2,7 @@ export class WitAiError extends Error {
   public code = 0;
   public response?: unknown;
   public url = "";
+  public bufferLength = -1;
 
   constructor(message = "WitAi request was unsuccessful", cause: Error) {
     super(`EWITAI ${message}`, { cause });
@@ -13,12 +14,27 @@ export class WitAiError extends Error {
   }
 
   public setResponse(response?: unknown): this {
-    this.response = response;
+    if (typeof response !== "string") {
+      this.response = { message: response };
+      return this;
+    }
+
+    try {
+      this.response = JSON.parse(response);
+    } catch (err) {
+      this.response = { message: response };
+    }
+
     return this;
   }
 
   public setUrl(url: string): this {
     this.url = url;
+    return this;
+  }
+
+  public setBufferLength(buff: Buffer): this {
+    this.bufferLength = buff?.length ?? -1;
     return this;
   }
 }

--- a/src/recognition/witai/wit.ai.ts
+++ b/src/recognition/witai/wit.ai.ts
@@ -118,7 +118,8 @@ export class WithAiProvider extends VoiceConverter {
         const witAiError = new WitAiError(err.message, err)
           .setUrl(url)
           .setErrorCode(err?.response?.status)
-          .setResponse(err?.response?.data);
+          .setResponse(err?.response?.data)
+          .setBufferLength(data);
         throw witAiError;
       });
   }


### PR DESCRIPTION
for some reason sematext can not properly parse wit ai response message. We try de-serializing it ourselves. if we unable to de-serialize it, we wrap it into object. This seems to be working fine