### PR TITLE
fix(server): Send empty favicon for browsers

### DIFF
--- a/src/server/express.ts
+++ b/src/server/express.ts
@@ -77,6 +77,9 @@ export class ExpressServer {
     this.app.get("/health", (_req, res: express.Response<HealthDto>) => {
       statusHandler(this.stat, res);
     });
+    this.app.get("/favicon.ico", (_req, res: express.Response<string>) => {
+      res.status(204).send("");
+    });
     this.app.get("/", (_req, res: express.Response<string>) => {
       logger.info("Received app root request");
       res.status(200).send("The app is running");


### PR DESCRIPTION
If we run the eg /health request in the browser, its will also request favicon.

Then this results in the error. We now send the empty response and do not consider this as an error