### PR TITLE
fix(validation): Use zod for language validation

### DIFF
--- a/e2e/errors.spec.ts
+++ b/e2e/errors.spec.ts
@@ -9,7 +9,10 @@ import {
 } from "@jest/globals";
 import request from "supertest";
 import nock from "nock";
-import { injectDependencies } from "../src/testUtils/dependencies.js";
+import {
+  injectDependencies,
+  InjectedFn,
+} from "../src/testUtils/dependencies.js";
 import { injectTestDependencies } from "./helpers/dependencies.js";
 import { Pool as MockPool } from "../src/db/__mocks__/pg.js";
 
@@ -30,10 +33,10 @@ const dbPort = appPort + 1;
 let stopHandler: () => Promise<void> = () =>
   Promise.reject(new Error("Server did not start"));
 
-let testPool;
-let telegramServer;
-let host;
-let bot;
+let testPool: MockPool;
+let telegramServer: nock.Scope;
+let host: request.SuperTest<request.Test>;
+let bot: InstanceType<InjectedFn["TelegramBotModel"]>;
 
 describe("error cases", () => {
   describe("server routes", () => {

--- a/e2e/group.en.spec.ts
+++ b/e2e/group.en.spec.ts
@@ -10,9 +10,18 @@ import {
   it,
   jest,
 } from "@jest/globals";
-import { injectDependencies } from "../src/testUtils/dependencies.js";
-import { injectTestDependencies } from "./helpers/dependencies.js";
+import {
+  injectDependencies,
+  InjectedFn,
+} from "../src/testUtils/dependencies.js";
+import {
+  InjectedTestFn,
+  injectTestDependencies,
+} from "./helpers/dependencies.js";
 import { Pool as MockPool } from "../src/db/__mocks__/pg.js";
+import { TgChatType } from "../src/telegram/api/types.js";
+import { VoiceConverterOptions } from "../src/recognition/types.js";
+import { LanguageCode } from "../src/recognition/types.js";
 
 jest.unstable_mockModule(
   "../src/logger/index",
@@ -40,41 +49,40 @@ let stopHandler: () => Promise<void> = () =>
   Promise.reject(new Error("Server did not start"));
 
 // Define dependencies
-let converterOptions;
-let converter;
+let converterOptions: VoiceConverterOptions;
+let converter: InstanceType<InjectedFn["VoiceConverter"]>;
 let hostUrl: string;
-let db;
-let bot;
-let telegramServer: nock.Scope;
-let host: request.SuperTest<request.Test>;
-let chatType;
+let db: InstanceType<InjectedFn["DbClient"]>;
+let bot: InstanceType<InjectedFn["TelegramBotModel"]>;
+let chatType: TgChatType;
 let testMessageId = 0;
 let testChatId = 0;
-let tgMessage;
-let mockTgReceiveUnexpectedMessage;
-let sendTelegramMessage;
-let mockUpdateBotStatUsage;
-let mockTgReceiveRawMessage;
-let mockTgGetFileUrl;
-let mockSpeechRecognition;
-let mockGetBotStatItem;
-let LanguageCode;
-let randomIntFromInterval;
-let TelegramMessageModel;
-let BotCommand;
-let LabelId;
-let mockTgReceiveMessages;
-let telegramBotName;
-let TelegramMessageMetaItem;
-let mockTgReceiveMessage;
-let TelegramMessageMetaType;
-let officialChannelAccount;
-let githubUrl;
-let getLangButtons;
-let sendTelegramCallbackMessage;
-let mockTgReceiveCallbackMessage;
-let mockUpdateBotStatLang;
-let getFundButtons;
+let tgMessage: InstanceType<InjectedTestFn["TelegramMessageModel"]>;
+let telegramServer: nock.Scope;
+let host: request.SuperTest<request.Test>;
+let mockTgReceiveUnexpectedMessage: InjectedTestFn["mockTgReceiveUnexpectedMessage"];
+let sendTelegramMessage: InjectedTestFn["sendTelegramMessage"];
+let mockUpdateBotStatUsage: InjectedTestFn["mockUpdateBotStatUsage"];
+let mockTgReceiveRawMessage: InjectedTestFn["mockTgReceiveRawMessage"];
+let mockTgGetFileUrl: InjectedTestFn["mockTgGetFileUrl"];
+let mockSpeechRecognition: InjectedTestFn["mockSpeechRecognition"];
+let mockGetBotStatItem: InjectedTestFn["mockGetBotStatItem"];
+let randomIntFromInterval: InjectedFn["randomIntFromInterval"];
+let TelegramMessageModel: InjectedTestFn["TelegramMessageModel"];
+let BotCommand: InjectedFn["BotCommand"];
+let LabelId: InjectedFn["LabelId"];
+let mockTgReceiveMessages: InjectedTestFn["mockTgReceiveMessages"];
+let telegramBotName: InjectedFn["telegramBotName"];
+let TelegramMessageMetaItem: InjectedTestFn["TelegramMessageMetaItem"];
+let mockTgReceiveMessage: InjectedTestFn["mockTgReceiveMessage"];
+let TelegramMessageMetaType: InjectedTestFn["TelegramMessageMetaType"];
+let officialChannelAccount: InjectedFn["officialChannelAccount"];
+let githubUrl: InjectedFn["githubUrl"];
+let getLangButtons: InjectedTestFn["getLangButtons"];
+let sendTelegramCallbackMessage: InjectedTestFn["sendTelegramCallbackMessage"];
+let mockTgReceiveCallbackMessage: InjectedTestFn["mockTgReceiveCallbackMessage"];
+let mockUpdateBotStatLang: InjectedTestFn["mockUpdateBotStatLang"];
+let getFundButtons: InjectedTestFn["getFundButtons"];
 // *EndOf Define dependencies
 
 describe("[default language - english]", () => {
@@ -90,7 +98,6 @@ describe("[default language - english]", () => {
     mockTgReceiveRawMessage = initTest.mockTgReceiveRawMessage;
     mockTgGetFileUrl = initTest.mockTgGetFileUrl;
     mockSpeechRecognition = initTest.mockSpeechRecognition;
-    LanguageCode = init.LanguageCode;
     randomIntFromInterval = init.randomIntFromInterval;
     TelegramMessageModel = initTest.TelegramMessageModel;
     BotCommand = init.BotCommand;
@@ -201,11 +208,7 @@ describe("[default language - english]", () => {
 
     it("responds on a /start message", () => {
       tgMessage.setText(testMessageId, BotCommand.Start);
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -228,11 +231,7 @@ describe("[default language - english]", () => {
         testMessageId,
         `${BotCommand.Start}@${telegramBotName}`
       );
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -252,11 +251,7 @@ describe("[default language - english]", () => {
 
     it("responds on a /support message", () => {
       tgMessage.setText(testMessageId, BotCommand.Support);
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -290,11 +285,7 @@ describe("[default language - english]", () => {
         testMessageId,
         `${BotCommand.Support}@${telegramBotName}`
       );
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -327,11 +318,7 @@ describe("[default language - english]", () => {
       const authorUrl = "some-author-url";
       bot.setAuthor(authorUrl);
       tgMessage.setText(testMessageId, BotCommand.Support);
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -375,11 +362,7 @@ describe("[default language - english]", () => {
         `${BotCommand.Support}@${telegramBotName}`
       );
 
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -417,11 +400,7 @@ describe("[default language - english]", () => {
 
     it("responds on a /lang message", () => {
       tgMessage.setText(testMessageId, BotCommand.Language);
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -440,11 +419,7 @@ describe("[default language - english]", () => {
         testMessageId,
         `${BotCommand.Language}@${telegramBotName}`
       );
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -460,11 +435,7 @@ describe("[default language - english]", () => {
 
     it("changes language using the /lang callback message", () => {
       tgMessage.setText(testMessageId, BotCommand.Language);
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -477,7 +448,7 @@ describe("[default language - english]", () => {
         ),
       ]).then(([, prefixId]) => {
         const cbMessage = new TelegramMessageModel(testChatId, chatType);
-        const newLangId = LanguageCode.Ru;
+        const newLangId: LanguageCode = "ru-RU";
         cbMessage.setLangCallback(tgMessage.messageId + 1, newLangId, prefixId);
         return Promise.all([
           sendTelegramCallbackMessage(host, bot, cbMessage),
@@ -498,11 +469,7 @@ describe("[default language - english]", () => {
         testMessageId,
         `${BotCommand.Language}@${telegramBotName}`
       );
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -515,7 +482,7 @@ describe("[default language - english]", () => {
         ),
       ]).then(([, prefixId]) => {
         const cbMessage = new TelegramMessageModel(testChatId, chatType);
-        const newLangId = LanguageCode.Ru;
+        const newLangId: LanguageCode = "ru-RU";
         cbMessage.setLangCallback(tgMessage.messageId + 1, newLangId, prefixId);
         return Promise.all([
           sendTelegramCallbackMessage(host, bot, cbMessage),
@@ -537,11 +504,7 @@ describe("[default language - english]", () => {
       const voiceFileContent = "supergroup";
       tgMessage.setVoice(testMessageId, voiceFileId, voiceFileDuration);
 
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       const speechScope = mockSpeechRecognition(voiceFileContent);
       mockTgGetFileUrl(telegramServer, tgMessage.voiceId);
@@ -567,11 +530,7 @@ describe("[default language - english]", () => {
       const userName = "test-user";
       tgMessage.setVoice(testMessageId, voiceFileId, voiceFileDuration);
       tgMessage.setName(testMessageId, { userName });
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       const speechScope = mockSpeechRecognition(voiceFileContent);
       mockTgGetFileUrl(telegramServer, tgMessage.voiceId);
@@ -592,11 +551,7 @@ describe("[default language - english]", () => {
 
     it("responds on a /fund message", () => {
       tgMessage.setText(testMessageId, BotCommand.Fund);
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -612,11 +567,7 @@ describe("[default language - english]", () => {
 
     it("responds on a /fund message with bot name", () => {
       tgMessage.setText(testMessageId, `${BotCommand.Fund}@${telegramBotName}`);
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       return Promise.all([
         sendTelegramMessage(host, bot, tgMessage),
@@ -642,11 +593,7 @@ describe("[default language - english]", () => {
         userName,
         firstName,
       });
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       const speechScope = mockSpeechRecognition(voiceFileContent);
       mockTgGetFileUrl(telegramServer, tgMessage.voiceId);
@@ -677,11 +624,7 @@ describe("[default language - english]", () => {
         userName,
         lastName,
       });
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       const speechScope = mockSpeechRecognition(voiceFileContent);
       mockTgGetFileUrl(telegramServer, tgMessage.voiceId);
@@ -714,11 +657,7 @@ describe("[default language - english]", () => {
         firstName,
         lastName,
       });
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       const speechScope = mockSpeechRecognition(voiceFileContent);
       mockTgGetFileUrl(telegramServer, tgMessage.voiceId);
@@ -835,11 +774,7 @@ describe("[default language - english]", () => {
       const voiceFileContent = "supergroup";
       tgMessage.setAudio(testMessageId, voiceFileId, voiceFileDuration);
 
-      const statModel = mockGetBotStatItem(
-        testPool,
-        tgMessage.chatId,
-        LanguageCode.En
-      );
+      const statModel = mockGetBotStatItem(testPool, tgMessage.chatId, "en-US");
 
       const speechScope = mockSpeechRecognition(voiceFileContent);
       mockTgGetFileUrl(telegramServer, tgMessage.voiceId);

--- a/e2e/group.ru.spec.ts
+++ b/e2e/group.ru.spec.ts
@@ -10,9 +10,18 @@ import {
   it,
   jest,
 } from "@jest/globals";
-import { injectDependencies } from "../src/testUtils/dependencies.js";
-import { injectTestDependencies } from "./helpers/dependencies.js";
+import {
+  injectDependencies,
+  InjectedFn,
+} from "../src/testUtils/dependencies.js";
+import {
+  InjectedTestFn,
+  injectTestDependencies,
+} from "./helpers/dependencies.js";
 import { Pool as MockPool } from "../src/db/__mocks__/pg.js";
+import { TgChatType } from "../src/telegram/api/types.js";
+import { VoiceConverterOptions } from "../src/recognition/types.js";
+import { LanguageCode } from "../src/recognition/types.js";
 
 jest.unstable_mockModule(
   "../src/logger/index",
@@ -40,44 +49,43 @@ let stopHandler: () => Promise<void> = () =>
   Promise.reject(new Error("Server did not start"));
 
 // Define dependencies
-let converterOptions;
-let converter;
+let converterOptions: VoiceConverterOptions;
+let converter: InstanceType<InjectedFn["VoiceConverter"]>;
 let hostUrl: string;
-let db;
-let bot;
+let db: InstanceType<InjectedFn["DbClient"]>;
+let bot: InstanceType<InjectedFn["TelegramBotModel"]>;
 let telegramServer: nock.Scope;
 let host: request.SuperTest<request.Test>;
-let chatType;
+let chatType: TgChatType;
 let testMessageId = 0;
 let testChatId = 0;
-let tgMessage;
-let mockTgReceiveUnexpectedMessage;
-let sendTelegramMessage;
-let mockUpdateBotStatUsage;
-let mockTgReceiveRawMessage;
-let mockTgGetFileUrl;
-let mockSpeechRecognition;
-let mockGetBotStatItem;
-let LanguageCode;
-let randomIntFromInterval;
-let TelegramMessageModel;
-let BotCommand;
-let LabelId;
-let mockTgReceiveMessages;
-let telegramBotName;
-let TelegramMessageMetaItem;
-let mockTgReceiveMessage;
-let TelegramMessageMetaType;
-let officialChannelAccount;
-let githubUrl;
-let getLangButtons;
-let sendTelegramCallbackMessage;
-let mockTgReceiveCallbackMessage;
-let mockUpdateBotStatLang;
-let getFundButtons;
-let botStat;
-let BotStatRecordModel;
-let testLangId;
+let tgMessage: InstanceType<InjectedTestFn["TelegramMessageModel"]>;
+let mockTgReceiveUnexpectedMessage: InjectedTestFn["mockTgReceiveUnexpectedMessage"];
+let sendTelegramMessage: InjectedTestFn["sendTelegramMessage"];
+let mockUpdateBotStatUsage: InjectedTestFn["mockUpdateBotStatUsage"];
+let mockTgReceiveRawMessage: InjectedTestFn["mockTgReceiveRawMessage"];
+let mockTgGetFileUrl: InjectedTestFn["mockTgGetFileUrl"];
+let mockSpeechRecognition: InjectedTestFn["mockSpeechRecognition"];
+let mockGetBotStatItem: InjectedTestFn["mockGetBotStatItem"];
+let randomIntFromInterval: InjectedFn["randomIntFromInterval"];
+let TelegramMessageModel: InjectedTestFn["TelegramMessageModel"];
+let BotCommand: InjectedFn["BotCommand"];
+let LabelId: InjectedFn["LabelId"];
+let mockTgReceiveMessages: InjectedTestFn["mockTgReceiveMessages"];
+let telegramBotName: InjectedFn["telegramBotName"];
+let TelegramMessageMetaItem: InjectedTestFn["TelegramMessageMetaItem"];
+let mockTgReceiveMessage: InjectedTestFn["mockTgReceiveMessage"];
+let TelegramMessageMetaType: InjectedTestFn["TelegramMessageMetaType"];
+let officialChannelAccount: InjectedFn["officialChannelAccount"];
+let githubUrl: InjectedFn["githubUrl"];
+let getLangButtons: InjectedTestFn["getLangButtons"];
+let sendTelegramCallbackMessage: InjectedTestFn["sendTelegramCallbackMessage"];
+let mockTgReceiveCallbackMessage: InjectedTestFn["mockTgReceiveCallbackMessage"];
+let mockUpdateBotStatLang: InjectedTestFn["mockUpdateBotStatLang"];
+let getFundButtons: InjectedTestFn["getFundButtons"];
+let botStat: InstanceType<InjectedTestFn["BotStatRecordModel"]>;
+let BotStatRecordModel: InjectedTestFn["BotStatRecordModel"];
+let testLangId: LanguageCode;
 // *EndOf Define dependencies
 
 describe("[russian language]", () => {
@@ -93,7 +101,6 @@ describe("[russian language]", () => {
     mockTgReceiveRawMessage = initTest.mockTgReceiveRawMessage;
     mockTgGetFileUrl = initTest.mockTgGetFileUrl;
     mockSpeechRecognition = initTest.mockSpeechRecognition;
-    LanguageCode = init.LanguageCode;
     randomIntFromInterval = init.randomIntFromInterval;
     TelegramMessageModel = initTest.TelegramMessageModel;
     BotCommand = init.BotCommand;
@@ -111,7 +118,7 @@ describe("[russian language]", () => {
     mockUpdateBotStatLang = initTest.mockUpdateBotStatLang;
     getFundButtons = initTest.getFundButtons;
     BotStatRecordModel = initTest.BotStatRecordModel;
-    testLangId = init.LanguageCode.Ru;
+    testLangId = "ru-RU";
 
     const mockGoogleAuth = initTest.mockGoogleAuth;
     const TelegramBotModel = init.TelegramBotModel;
@@ -493,7 +500,7 @@ describe("[russian language]", () => {
         ),
       ]).then(([, prefixId]) => {
         const cbMessage = new TelegramMessageModel(testChatId, chatType);
-        const newLangId = LanguageCode.Ru;
+        const newLangId: LanguageCode = "ru-RU";
         cbMessage.setLangCallback(tgMessage.messageId + 1, newLangId, prefixId);
         return Promise.all([
           sendTelegramCallbackMessage(host, bot, cbMessage),
@@ -532,7 +539,7 @@ describe("[russian language]", () => {
         ),
       ]).then(([, prefixId]) => {
         const cbMessage = new TelegramMessageModel(testChatId, chatType);
-        const newLangId = LanguageCode.En;
+        const newLangId: LanguageCode = "en-US";
         cbMessage.setLangCallback(tgMessage.messageId + 1, newLangId, prefixId);
         return Promise.all([
           sendTelegramCallbackMessage(host, bot, cbMessage),

--- a/e2e/health.spec.ts
+++ b/e2e/health.spec.ts
@@ -11,8 +11,14 @@ import request from "supertest";
 import nock from "nock";
 import { Pool as MockPool } from "../src/db/__mocks__/pg.js";
 import { HealthSsl, HealthStatus } from "../src/server/types.js";
-import { injectDependencies } from "../src/testUtils/dependencies.js";
-import { injectTestDependencies } from "./helpers/dependencies.js";
+import {
+  injectDependencies,
+  InjectedFn,
+} from "../src/testUtils/dependencies.js";
+import {
+  InjectedTestFn,
+  injectTestDependencies,
+} from "./helpers/dependencies.js";
 
 jest.unstable_mockModule(
   "../src/logger/index",
@@ -28,20 +34,20 @@ const enableSSL = false;
 const appPort = 3300;
 const dbPort = appPort + 1;
 
-let hostUrl;
-let server;
-let telegramServer;
-let host;
-let ExpressServer;
-let appVersion;
-let httpsOptions;
-let testPool;
-let mockTgGetWebHook;
-let mockTgSetWebHook;
-let mockTgSetCommands;
-let mockTgGetWebHookError;
-let bot;
-let localhostUrl;
+let hostUrl: string;
+let server: InstanceType<InjectedFn["ExpressServer"]>;
+let telegramServer: nock.Scope;
+let host: request.SuperTest<request.Test>;
+let ExpressServer: InjectedFn["ExpressServer"];
+let appVersion: InjectedFn["appVersion"];
+let httpsOptions: InjectedFn["httpsOptions"];
+let testPool: MockPool;
+let mockTgGetWebHook: InjectedTestFn["mockTgGetWebHook"];
+let mockTgSetWebHook: InjectedTestFn["mockTgSetWebHook"];
+let mockTgSetCommands: InjectedTestFn["mockTgSetCommands"];
+let mockTgGetWebHookError: InjectedTestFn["mockTgGetWebHookError"];
+let bot: InstanceType<InjectedFn["TelegramBotModel"]>;
+let localhostUrl: string;
 
 const path = "/health";
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -97,7 +97,7 @@ export class TelegramMessageModel {
     prefixId: string
   ): this {
     this.messageId = messageId;
-    const data = new TelegramButtonModel(
+    const data = new TelegramButtonModel<LanguageCode>(
       TelegramButtonType.Language,
       langId,
       prefixId
@@ -204,7 +204,7 @@ export class BotStatRecordModel {
   public user = "";
   public usageCount = 0;
 
-  constructor(public chatId: number, public langId = LanguageCode.En) {}
+  constructor(public chatId: number, public langId: LanguageCode = "en-US") {}
 
   public setObjectId(objectId: number): this {
     this.objectId = String(objectId);
@@ -250,7 +250,7 @@ export const getLangButtons = (): TelegramMessageMetaItem[][] => {
       new TelegramMessageMetaItem(
         TelegramMessageMetaType.Button,
         LabelId.BtnRussian,
-        LanguageCode.Ru,
+        "ru-RU",
         TelegramButtonType.Language
       ),
     ],
@@ -258,7 +258,7 @@ export const getLangButtons = (): TelegramMessageMetaItem[][] => {
       new TelegramMessageMetaItem(
         TelegramMessageMetaType.Button,
         LabelId.BtnEnglish,
-        LanguageCode.En,
+        "en-US",
         TelegramButtonType.Language
       ),
     ],

--- a/e2e/helpers/dependencies.ts
+++ b/e2e/helpers/dependencies.ts
@@ -13,3 +13,5 @@ export const injectTestDependencies = async () => {
     ...donationStats,
   };
 };
+
+export type InjectedTestFn = Awaited<ReturnType<typeof injectTestDependencies>>;

--- a/e2e/lifecycle.spec.ts
+++ b/e2e/lifecycle.spec.ts
@@ -10,8 +10,14 @@ import {
 import request from "supertest";
 import nock from "nock";
 import { Pool as MockPool } from "../src/db/__mocks__/pg.js";
-import { injectDependencies } from "../src/testUtils/dependencies.js";
-import { injectTestDependencies } from "./helpers/dependencies.js";
+import {
+  injectDependencies,
+  InjectedFn,
+} from "../src/testUtils/dependencies.js";
+import {
+  injectTestDependencies,
+  InjectedTestFn,
+} from "./helpers/dependencies.js";
 import { HealthSsl, HealthStatus } from "../src/server/types.js";
 
 jest.unstable_mockModule(
@@ -33,18 +39,18 @@ const path = "/lifecycle";
 let stopHandler: () => Promise<void> = () =>
   Promise.reject(new Error("Server did not start"));
 
-let server;
-let localhostUrl;
-let ExpressServer;
-let appVersion;
-let httpsOptions;
-let telegramServer;
-let testPool;
-let host;
-let mockTgGetWebHook;
-let hostUrl;
-let bot;
-let mockTgGetWebHookError;
+let server: InstanceType<InjectedFn["ExpressServer"]>;
+let localhostUrl: string;
+let ExpressServer: InjectedFn["ExpressServer"];
+let appVersion: InjectedFn["appVersion"];
+let httpsOptions: InjectedFn["httpsOptions"];
+let telegramServer: nock.Scope;
+let testPool: MockPool;
+let host: request.SuperTest<request.Test>;
+let mockTgGetWebHook: InjectedTestFn["mockTgGetWebHook"];
+let hostUrl: string;
+let bot: InstanceType<InjectedFn["TelegramBotModel"]>;
+let mockTgGetWebHookError: InjectedTestFn["mockTgGetWebHookError"];
 
 describe("[lifecycle]", () => {
   beforeAll(async () => {

--- a/e2e/scheduler.spec.ts
+++ b/e2e/scheduler.spec.ts
@@ -7,8 +7,12 @@ import {
   describe,
   beforeAll,
 } from "@jest/globals";
-import { injectDependencies } from "../src/testUtils/dependencies.js";
+import {
+  injectDependencies,
+  InjectedFn,
+} from "../src/testUtils/dependencies.js";
 import { HealthDto, HealthSsl, HealthStatus } from "../src/server/types.js";
+import { SpiedFunction } from "jest-mock";
 
 jest.unstable_mockModule(
   "../src/logger/index",
@@ -51,13 +55,13 @@ let clearIntervalSpy = jest
 const oneMinute = 60_000;
 const oneDayMinutes = 24 * 60;
 
-let server;
-let requestHealthData;
-let ExpressServer;
-let appVersion;
-let httpsOptions;
-let waiter;
-let hostUrl;
+let server: InstanceType<InjectedFn["ExpressServer"]>;
+let requestHealthData: SpiedFunction<InjectedFn["requestHealthData"]>;
+let ExpressServer: InjectedFn["ExpressServer"];
+let appVersion: InjectedFn["appVersion"];
+let httpsOptions: InjectedFn["httpsOptions"];
+let waiter: InstanceType<InjectedFn["WaiterForCalls"]>;
+let hostUrl: string;
 const enableSSL = false;
 
 let stopHandler: () => Promise<void> = () =>
@@ -66,7 +70,7 @@ let stopHandler: () => Promise<void> = () =>
 describe("[uptime daemon]", () => {
   beforeAll(async () => {
     const init = await injectDependencies();
-    requestHealthData = init.requestHealthData;
+    requestHealthData = jest.spyOn(init, "requestHealthData");
     ExpressServer = init.ExpressServer;
     appVersion = init.appVersion;
     httpsOptions = init.httpsOptions;

--- a/src/common/environment.ts
+++ b/src/common/environment.ts
@@ -1,5 +1,5 @@
 import { nodeEnvironment } from "../env.js";
 
-export const isDevelopment = () => {
+export const isDevelopment = (): boolean => {
   return nodeEnvironment === "development";
 };

--- a/src/common/helpers.spec.ts
+++ b/src/common/helpers.spec.ts
@@ -1,29 +1,24 @@
 import { describe, expect, it } from "@jest/globals";
 import { splitTextIntoParts } from "./helpers.js";
-import { LanguageCode } from "../recognition/types.js";
 
 describe("common helpers", () => {
   describe("splitTextIntoParts", () => {
     it("should return the array of the same text if it is less than the max size", () => {
       const text = "one two three";
       const maxLength = text.length + 1;
-      expect(splitTextIntoParts(text, LanguageCode.En, maxLength)).toEqual([
-        text,
-      ]);
+      expect(splitTextIntoParts(text, "en-US", maxLength)).toEqual([text]);
     });
 
     it("should return the array of the same text if it is equal to the max size", () => {
       const text = "one two three";
       const maxLength = text.length;
-      expect(splitTextIntoParts(text, LanguageCode.En, maxLength)).toEqual([
-        text,
-      ]);
+      expect(splitTextIntoParts(text, "en-US", maxLength)).toEqual([text]);
     });
 
     it("should return the parts of the text if the text is longer than max size", () => {
       const text = "one two three";
       const maxLength = 7;
-      expect(splitTextIntoParts(text, LanguageCode.En, maxLength)).toEqual([
+      expect(splitTextIntoParts(text, "en-US", maxLength)).toEqual([
         "one two",
         "three",
       ]);
@@ -32,7 +27,7 @@ describe("common helpers", () => {
     it("should not return the trailing whitespace in the last part", () => {
       const text = "one two three ";
       const maxLength = text.length - 1;
-      expect(splitTextIntoParts(text, LanguageCode.En, maxLength)).toEqual([
+      expect(splitTextIntoParts(text, "en-US", maxLength)).toEqual([
         "one two three",
       ]);
     });

--- a/src/db/donations.spec.ts
+++ b/src/db/donations.spec.ts
@@ -8,7 +8,7 @@ import {
   jest,
 } from "@jest/globals";
 import { Pool as MockPool } from "./__mocks__/pg.js";
-import { injectDependencies } from "../testUtils/dependencies.js";
+import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",
@@ -23,11 +23,11 @@ const dbConfig = {
   port: 5432,
 };
 
-let DonationsSql;
-let DonationsClient;
-let DonationStatus;
+let DonationsSql: InjectedFn["DonationsSql"];
+let DonationsClient: InjectedFn["DonationsClient"];
+let DonationStatus: InjectedFn["DonationStatus"];
 let testPool = new MockPool(dbConfig);
-let client;
+let client: InstanceType<InjectedFn["DonationsClient"]>;
 
 describe("Donations DB", () => {
   beforeAll(async () => {

--- a/src/db/emails.spec.ts
+++ b/src/db/emails.spec.ts
@@ -8,7 +8,7 @@ import {
   beforeAll,
 } from "@jest/globals";
 import { Pool as MockPool } from "./__mocks__/pg.js";
-import { injectDependencies } from "../testUtils/dependencies.js";
+import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",
@@ -23,9 +23,9 @@ const dbConfig = {
   port: 5432,
 };
 
-let UsedEmailsSql;
-let UsedEmailClient;
-let client;
+let UsedEmailsSql: InjectedFn["UsedEmailsSql"];
+let UsedEmailClient: InjectedFn["UsedEmailClient"];
+let client: InstanceType<InjectedFn["UsedEmailClient"]>;
 let testPool = new MockPool(dbConfig);
 
 describe("Used Emails DB", () => {

--- a/src/db/nodes.spec.ts
+++ b/src/db/nodes.spec.ts
@@ -8,7 +8,7 @@ import {
   beforeAll,
 } from "@jest/globals";
 import { Pool as MockPool } from "./__mocks__/pg.js";
-import { injectDependencies } from "../testUtils/dependencies.js";
+import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",
@@ -23,10 +23,10 @@ const dbConfig = {
   port: 5432,
 };
 
-let NodesSql;
-let NodesClient;
+let NodesSql: InjectedFn["NodesSql"];
+let NodesClient: InjectedFn["NodesClient"];
 let testPool = new MockPool(dbConfig);
-let client;
+let client: InstanceType<InjectedFn["NodesClient"]>;
 
 describe("Nodes DB", () => {
   beforeAll(async () => {

--- a/src/monitoring/sentry.ts
+++ b/src/monitoring/sentry.ts
@@ -30,7 +30,7 @@ export const initSentry = (app: Express): void => {
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production
-    tracesSampleRate: isDevelopment() ? 1.0 : 0.2,
+    tracesSampleRate: isDevelopment() ? 1.0 : 0.05,
     profilesSampleRate: 1.0,
   });
 };

--- a/src/recognition/types.ts
+++ b/src/recognition/types.ts
@@ -27,10 +27,13 @@ export interface VoiceConverterOptions {
   witAiTokenRu?: string;
 }
 
-export enum LanguageCode {
-  Ru = "ru-RU",
-  En = "en-US",
-}
+export const LanguageSchema = z
+  .union([z.literal("en-US"), z.literal("ru-RU")])
+  .describe("Supported language codes");
+
+export type LanguageCode = z.infer<typeof LanguageSchema>;
+
+export const DEFAULT_LANGUAGE: LanguageCode = "en-US";
 
 export interface ConverterMeta {
   fileId: string;

--- a/src/recognition/witai/wit.ai.ts
+++ b/src/recognition/witai/wit.ai.ts
@@ -40,7 +40,7 @@ export class WithAiProvider extends VoiceConverter {
     return getWav(fileLink, isVideo)
       .then((bufferData) => {
         logger.info(`${logData.prefix} Start converting ${Logger.y(name)}`);
-        const token = lang === LanguageCode.Ru ? this.tokenRu : this.tokenEn;
+        const token = this.getApiToken(lang);
         return WithAiProvider.recognise(bufferData, token, logData.prefix);
       })
       .then((chunks) => chunks.map(({ text }) => text).join(" ") || "");
@@ -152,6 +152,15 @@ export class WithAiProvider extends VoiceConverter {
           .setBufferLength(data);
         throw witAiError;
       });
+  }
+
+  private getApiToken(lang: LanguageCode): string {
+    switch (lang) {
+      case "ru-RU":
+        return this.tokenRu;
+      default:
+        return this.tokenEn;
+    }
   }
 }
 

--- a/src/scheduler/scheduler.spec.ts
+++ b/src/scheduler/scheduler.spec.ts
@@ -8,7 +8,8 @@ import {
   beforeAll,
 } from "@jest/globals";
 import { nanoid } from "nanoid";
-import { injectDependencies } from "../testUtils/dependencies.js";
+import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
+import { Mock } from "jest-mock";
 
 jest.unstable_mockModule(
   "../logger/index",
@@ -20,21 +21,21 @@ jest.useFakeTimers();
 const oneMinute = 60_000;
 
 let finishResult = Promise.resolve();
-let finishWatcher;
-let finishFn;
+let finishWatcher: InstanceType<InjectedFn["WaiterForCalls"]>;
+let finishFn: Mock<() => Promise<void>>;
 
 let shouldFinishResult = false;
-let shouldFinishWatcher;
-let shouldFinishFn;
+let shouldFinishWatcher: InstanceType<InjectedFn["WaiterForCalls"]>;
+let shouldFinishFn: Mock<() => boolean>;
 
 let tickResult = Promise.resolve("");
-let tickWatcher;
-let tickFn;
+let tickWatcher: InstanceType<InjectedFn["WaiterForCalls"]>;
+let tickFn: Mock<() => Promise<string>>;
 
-let ScheduleDaemon: Awaited<typeof import("./index.js").ScheduleDaemon>;
-let WaiterForCalls;
+let ScheduleDaemon: InjectedFn["ScheduleDaemon"];
+let WaiterForCalls: InjectedFn["WaiterForCalls"];
 let testId = nanoid(10);
-let scheduler;
+let scheduler: InstanceType<InjectedFn["ScheduleDaemon"]>;
 
 describe("Scheduler", () => {
   beforeAll(async () => {
@@ -64,7 +65,7 @@ describe("Scheduler", () => {
   beforeEach(() => {
     finishResult = Promise.resolve();
     testId = nanoid(10);
-    scheduler = new ScheduleDaemon<string>(testId, tickFn);
+    scheduler = new ScheduleDaemon<unknown>(testId, tickFn);
   });
 
   afterEach(() => {

--- a/src/server/tunnel.spec.ts
+++ b/src/server/tunnel.spec.ts
@@ -1,12 +1,12 @@
 import { it, describe, expect, jest, beforeAll } from "@jest/globals";
-import { injectDependencies } from "../testUtils/dependencies.js";
+import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",
   () => import("../logger/__mocks__/index.js")
 );
 
-let getHostName;
+let getHostName: InjectedFn["getHostName"];
 
 describe("Tunnel handling", () => {
   beforeAll(async () => {

--- a/src/statistic/cache.spec.ts
+++ b/src/statistic/cache.spec.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it, jest, beforeAll } from "@jest/globals";
-import { injectDependencies } from "../testUtils/dependencies.js";
+import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",
@@ -25,7 +25,7 @@ const item3: TestCacheData = { testId: testId3, testData: testData3 };
 
 let cacheSize = 0;
 let CacheProvider: Awaited<typeof import("./cache.js").CacheProvider>;
-let cache;
+let cache: InstanceType<InjectedFn["CacheProvider"]>;
 
 describe("[cache]", () => {
   beforeAll(async () => {

--- a/src/telegram/actions/lang.ts
+++ b/src/telegram/actions/lang.ts
@@ -172,12 +172,12 @@ export class LangAction extends GenericAction {
       .then((lang) => {
         const EnData = new TelegramButtonModel(
           TelegramButtonType.Language,
-          LanguageCode.En,
+          "en-US",
           prefix.id
         );
         const RuData = new TelegramButtonModel(
           TelegramButtonType.Language,
-          LanguageCode.Ru,
+          "ru-RU",
           prefix.id
         );
 

--- a/src/telegram/helpers.spec.ts
+++ b/src/telegram/helpers.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
 import { TgMessage } from "./api/types.js";
-import { getUserLanguage } from "./helpers.js";
-import { LanguageCode } from "../recognition/types.js";
+import { getUserLanguage, getLanguageByText } from "./helpers.js";
+import { DEFAULT_LANGUAGE, LanguageCode } from "../recognition/types.js";
 
 const getMessage = (name?: string, lang?: string): TgMessage => {
   return {
@@ -26,67 +26,95 @@ describe("telegram helpers", () => {
     it("falls back to EN is no from field presented", () => {
       const msg = getMessage();
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.En);
+      expect(lang).toBe("en-US");
     });
 
     it("falls back to EN is no language_code field presented", () => {
       const msg = getMessage("test-name");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.En);
+      expect(lang).toBe("en-US");
     });
 
     it("returns RU if it eq to ru", () => {
       const msg = getMessage("test-name", "ru");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.Ru);
+      expect(lang).toBe("ru-RU");
     });
 
     it("returns RU if it eq to RU", () => {
       const msg = getMessage("test-name", "RU");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.Ru);
+      expect(lang).toBe("ru-RU");
     });
 
     it("returns RU if it eq to ru-RU", () => {
       const msg = getMessage("test-name", "ru-RU");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.Ru);
+      expect(lang).toBe("ru-RU");
     });
 
     it("returns EN if it eq to es", () => {
       const msg = getMessage("test-name", "es");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.En);
+      expect(lang).toBe("en-US");
     });
 
     it("returns EN if it eq to dssdfsf", () => {
       const msg = getMessage("test-name", "dssdfsf");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.En);
+      expect(lang).toBe("en-US");
     });
 
     it("returns EN if it eq to en", () => {
       const msg = getMessage("test-name", "en");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.En);
+      expect(lang).toBe("en-US");
     });
 
     it("returns EN if it eq to EN", () => {
       const msg = getMessage("test-name", "EN");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.En);
+      expect(lang).toBe("en-US");
     });
 
     it("returns EN if it eq to en-US", () => {
       const msg = getMessage("test-name", "en-US");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.En);
+      expect(lang).toBe("en-US");
     });
 
     it("returns EN if it eq to en-GB", () => {
       const msg = getMessage("test-name", "en-GB");
       const lang = getUserLanguage(msg);
-      expect(lang).toBe(LanguageCode.En);
+      expect(lang).toBe("en-US");
     });
+  });
+
+  describe("getLanguageByText", () => {
+    it("should return the language if it is supported", () => {
+      const supported: LanguageCode[] = ["en-US", "ru-RU"];
+      supported.forEach((lng) => {
+        expect(getLanguageByText(lng)).toBe(lng);
+        expect(getLanguageByText(lng, false)).toBe(lng);
+        expect(getLanguageByText(lng, true)).toBe(lng);
+      });
+    });
+
+    it.each([[""], ["en-GB"], ["es-ES"], ["foo"]])(
+      "should return default language if the input was %s and re-throwing errors disabled",
+      (lng) => {
+        expect(getLanguageByText(lng)).toBe(DEFAULT_LANGUAGE);
+        expect(getLanguageByText(lng, false)).toBe(DEFAULT_LANGUAGE);
+      }
+    );
+
+    it.each([[""], ["en-GB"], ["es-ES"], ["foo"]])(
+      "should throw an error if the input was %s and re-throwing errors enabled",
+      (lng) => {
+        expect(() => getLanguageByText(lng, true)).toThrowError(
+          `Language code ${lng} is not recognized`
+        );
+      }
+    );
   });
 });

--- a/src/telegram/helpers.ts
+++ b/src/telegram/helpers.ts
@@ -9,7 +9,11 @@ import {
 } from "./types.js";
 import { telegramBotName } from "../env.js";
 import { TgCallbackQuery, TgMedia, TgMessage } from "./api/types.js";
-import { LanguageCode } from "../recognition/types.js";
+import {
+  DEFAULT_LANGUAGE,
+  LanguageCode,
+  LanguageSchema,
+} from "../recognition/types.js";
 import { durationLimitSec, supportedAudioFormats } from "../const.js";
 
 export const isLangMessage = (
@@ -164,10 +168,10 @@ export const getUserLanguage = (msg: TgMessage): LanguageCode => {
   const globalPart = msgLang.slice(0, 2).toLowerCase();
 
   if (globalPart === "ru") {
-    return LanguageCode.Ru;
+    return "ru-RU";
   }
 
-  return LanguageCode.En;
+  return "en-US";
 };
 
 export const getRawUserLanguage = (
@@ -180,18 +184,15 @@ export const getLanguageByText = (
   lang: string,
   throwOnError = false
 ): LanguageCode => {
-  switch (lang) {
-    case LanguageCode.Ru:
-      return LanguageCode.Ru;
-    case LanguageCode.En:
-      return LanguageCode.En;
-    default: {
-      if (!throwOnError) {
-        return LanguageCode.En;
-      }
-
-      throw new Error(`Language code ${lang} is not recognized`);
+  try {
+    const lng = LanguageSchema.parse(lang);
+    return lng;
+  } catch (err) {
+    if (!throwOnError) {
+      return DEFAULT_LANGUAGE;
     }
+
+    throw new Error(`Language code ${lang} is not recognized`, { cause: err });
   }
 };
 

--- a/src/telegram/types.ts
+++ b/src/telegram/types.ts
@@ -121,7 +121,7 @@ export enum TelegramButtonType {
   Unknown = "u",
 }
 
-export class TelegramButtonModel {
+export class TelegramButtonModel<V extends string = string> {
   public static fromDto(dtoString: string): TelegramButtonModel {
     const dto: BotButtonDto = JSON.parse(dtoString);
     const type = getButtonTypeByText(dto.i);
@@ -130,7 +130,7 @@ export class TelegramButtonModel {
 
   constructor(
     public readonly id: TelegramButtonType,
-    public readonly value: string,
+    public readonly value: V,
     public readonly logPrefix: string
   ) {}
 

--- a/src/testUtils/dependencies.ts
+++ b/src/testUtils/dependencies.ts
@@ -59,3 +59,5 @@ export const injectDependencies = async () => {
     ...usages,
   };
 };
+
+export type InjectedFn = Awaited<ReturnType<typeof injectDependencies>>;

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -10,7 +10,7 @@ export const sSuffix = (word: string, count: number | boolean): string => {
 };
 
 export class TextModel {
-  private readonly cbLang = LanguageCode.En;
+  private readonly cbLang: LanguageCode = "en-US";
 
   public static toCurrency(amount: number, meta?: string): string {
     const amountStr = `${amount} €`;

--- a/src/text/labels.ts
+++ b/src/text/labels.ts
@@ -73,7 +73,7 @@ export const menuLabels: Record<MenuLabel, string> = {
 
 export const labels: Record<LanguageCode, Record<LabelWithNoMenu, string>> = {
   // Russian
-  [LanguageCode.Ru]: {
+  ["ru-RU"]: {
     // "start" command
     [LabelId.WelcomeMessage]:
       "👋🏽 Привет! отправь мне голосовое сообщение и я распознаю его в текст",
@@ -137,7 +137,7 @@ export const labels: Record<LanguageCode, Record<LabelWithNoMenu, string>> = {
     [LabelId.RecognitionEmpty]: "Я не смог найти текст в сообщении 🤔",
   },
   // English
-  [LanguageCode.En]: {
+  ["en-US"]: {
     // "start" command
     [LabelId.WelcomeMessage]:
       "👋🏽 Hey there! Send me a voice message and I will show what they are talking about in plain text",


### PR DESCRIPTION
Gradually replace all validation utilities with zod
parser. Eventually this leads us to using string type
literals instead of enums. Hence we will be gradually
refactoring all the enums for consistency. LanguageCode
is the most widely used one.

Here we also add more types for test files in
order to be able to do future refactorings