### PR TITLE
fix(server): Rename ExpressServer

### DIFF
--- a/e2e/dm.en.spec.ts
+++ b/e2e/dm.en.spec.ts
@@ -117,7 +117,7 @@ describe("[default language - english]", () => {
     const TelegramBotModel = init.TelegramBotModel;
     const TelegramApi = init.TelegramApi;
     const mockTgGetWebHook = initTest.mockTgGetWebHook;
-    const ExpressServer = init.ExpressServer;
+    const BotServer = init.BotServer;
     const appVersion = init.appVersion;
     const httpsOptions = init.httpsOptions;
     const launchTime = init.launchTime;
@@ -161,7 +161,7 @@ describe("[default language - english]", () => {
 
     mockTgGetWebHook(telegramServer, `${hostUrl}${bot.getPath()}`);
 
-    const server = new ExpressServer(
+    const server = new BotServer(
       appPort,
       enableSSL,
       appVersion,

--- a/e2e/dm.ru.spec.ts
+++ b/e2e/dm.ru.spec.ts
@@ -124,7 +124,7 @@ describe("[russian language]", () => {
     const mockTgGetWebHook = initTest.mockTgGetWebHook;
     const mockTgSetWebHook = initTest.mockTgSetWebHook;
     const mockTgSetCommands = initTest.mockTgSetCommands;
-    const ExpressServer = init.ExpressServer;
+    const BotServer = init.BotServer;
     const appVersion = init.appVersion;
     const httpsOptions = init.httpsOptions;
     const launchTime = init.launchTime;
@@ -172,7 +172,7 @@ describe("[russian language]", () => {
     mockTgSetWebHook(telegramServer, `${hostUrl}${bot.getPath()}`);
     mockTgSetCommands(telegramServer);
 
-    const server = new ExpressServer(
+    const server = new BotServer(
       appPort,
       enableSSL,
       appVersion,

--- a/e2e/donate.spec.ts
+++ b/e2e/donate.spec.ts
@@ -112,7 +112,7 @@ describe("[default language - english] donate", () => {
     const TelegramApi = init.TelegramApi;
     const StripePayment = init.StripePayment;
     const mockTgGetWebHook = initTest.mockTgGetWebHook;
-    const ExpressServer = init.ExpressServer;
+    const BotServer = init.BotServer;
     const appVersion = init.appVersion;
     const httpsOptions = init.httpsOptions;
 
@@ -145,7 +145,7 @@ describe("[default language - english] donate", () => {
 
     mockTgGetWebHook(telegramServer, `${hostUrl}${bot.getPath()}`);
 
-    const server = new ExpressServer(
+    const server = new BotServer(
       appPort,
       enableSSL,
       appVersion,

--- a/e2e/errors.spec.ts
+++ b/e2e/errors.spec.ts
@@ -58,7 +58,7 @@ describe("error cases", () => {
       const mockTgGetWebHook = initTest.mockTgGetWebHook;
       const mockTgSetWebHook = initTest.mockTgSetWebHook;
       const mockTgSetCommands = initTest.mockTgSetCommands;
-      const ExpressServer = init.ExpressServer;
+      const BotServer = init.BotServer;
       const appVersion = init.appVersion;
       const httpsOptions = init.httpsOptions;
       const launchTime = init.launchTime;
@@ -100,7 +100,7 @@ describe("error cases", () => {
       mockTgSetWebHook(telegramServer, `${hostUrl}${bot.getPath()}`);
       mockTgSetCommands(telegramServer);
 
-      const server = new ExpressServer(
+      const server = new BotServer(
         appPort,
         enableSSL,
         appVersion,

--- a/e2e/group.en.spec.ts
+++ b/e2e/group.en.spec.ts
@@ -134,7 +134,7 @@ describe("[default language - english]", () => {
     const getMockCertificate = initTest.getMockCertificate;
     const getVoiceConverterInstance = init.getVoiceConverterInstance;
     const getVoiceConverterProvider = init.getVoiceConverterProvider;
-    const ExpressServer = init.ExpressServer;
+    const BotServer = init.BotServer;
     const appVersion = init.appVersion;
     const httpsOptions = init.httpsOptions;
     const TelegramApi = init.TelegramApi;
@@ -170,7 +170,7 @@ describe("[default language - english]", () => {
     mockTgSetWebHook(telegramServer, `${hostUrl}${bot.getPath()}`);
     mockTgSetCommands(telegramServer);
 
-    const server = new ExpressServer(
+    const server = new BotServer(
       appPort,
       enableSSL,
       appVersion,

--- a/e2e/group.ru.spec.ts
+++ b/e2e/group.ru.spec.ts
@@ -139,7 +139,7 @@ describe("[russian language]", () => {
     const getMockCertificate = initTest.getMockCertificate;
     const getVoiceConverterInstance = init.getVoiceConverterInstance;
     const getVoiceConverterProvider = init.getVoiceConverterProvider;
-    const ExpressServer = init.ExpressServer;
+    const BotServer = init.BotServer;
     const appVersion = init.appVersion;
     const httpsOptions = init.httpsOptions;
     const TelegramApi = init.TelegramApi;
@@ -175,7 +175,7 @@ describe("[russian language]", () => {
     mockTgSetWebHook(telegramServer, `${hostUrl}${bot.getPath()}`);
     mockTgSetCommands(telegramServer);
 
-    const server = new ExpressServer(
+    const server = new BotServer(
       appPort,
       enableSSL,
       appVersion,

--- a/e2e/health.spec.ts
+++ b/e2e/health.spec.ts
@@ -37,10 +37,10 @@ const dbPort = appPort + 1;
 const webhookDoNotWait = false;
 
 let hostUrl: string;
-let server: InstanceType<InjectedFn["ExpressServer"]>;
+let server: InstanceType<InjectedFn["BotServer"]>;
 let telegramServer: nock.Scope;
 let host: request.Agent;
-let ExpressServer: InjectedFn["ExpressServer"];
+let BotServer: InjectedFn["BotServer"];
 let appVersion: InjectedFn["appVersion"];
 let httpsOptions: InjectedFn["httpsOptions"];
 let testPool: MockPool;
@@ -61,7 +61,7 @@ describe("[health]", () => {
     const init = await injectDependencies();
     const initTest = await injectTestDependencies();
 
-    ExpressServer = init.ExpressServer;
+    BotServer = init.BotServer;
     appVersion = init.appVersion;
     httpsOptions = init.httpsOptions;
     mockTgGetWebHook = initTest.mockTgGetWebHook;
@@ -112,7 +112,7 @@ describe("[health]", () => {
   });
 
   beforeEach(() => {
-    server = new ExpressServer(
+    server = new BotServer(
       appPort,
       enableSSL,
       appVersion,

--- a/e2e/ignore.spec-ignored.ts
+++ b/e2e/ignore.spec-ignored.ts
@@ -81,7 +81,7 @@ describe("ignore chats", () => {
     const TelegramBotModel = init.TelegramBotModel;
     const TelegramApi = init.TelegramApi;
     const mockTgGetWebHook = initTest.mockTgGetWebHook;
-    const ExpressServer = init.ExpressServer;
+    const BotServer = init.BotServer;
     const appVersion = init.appVersion;
     const httpsOptions = init.httpsOptions;
     const launchTime = init.launchTime;
@@ -122,7 +122,7 @@ describe("ignore chats", () => {
 
     mockTgGetWebHook(telegramServer, `${hostUrl}${bot.getPath()}`);
 
-    const server = new ExpressServer(
+    const server = new BotServer(
       appPort,
       enableSSL,
       appVersion,

--- a/e2e/lifecycle.spec.ts
+++ b/e2e/lifecycle.spec.ts
@@ -41,9 +41,9 @@ const path = "/lifecycle";
 let stopHandler: VoidPromise = () =>
   Promise.reject(new Error("Server did not start"));
 
-let server: InstanceType<InjectedFn["ExpressServer"]>;
+let server: InstanceType<InjectedFn["BotServer"]>;
 let localhostUrl: string;
-let ExpressServer: InjectedFn["ExpressServer"];
+let BotServer: InjectedFn["BotServer"];
 let appVersion: InjectedFn["appVersion"];
 let httpsOptions: InjectedFn["httpsOptions"];
 let telegramServer: nock.Scope;
@@ -59,7 +59,7 @@ describe("[lifecycle]", () => {
     const init = await injectDependencies();
     const initTest = await injectTestDependencies();
 
-    ExpressServer = init.ExpressServer;
+    BotServer = init.BotServer;
     appVersion = init.appVersion;
     httpsOptions = init.httpsOptions;
     mockTgGetWebHook = initTest.mockTgGetWebHook;
@@ -111,7 +111,7 @@ describe("[lifecycle]", () => {
   });
 
   beforeEach(() => {
-    server = new ExpressServer(
+    server = new BotServer(
       appPort,
       enableSSL,
       appVersion,

--- a/e2e/scheduler.spec.ts
+++ b/e2e/scheduler.spec.ts
@@ -56,9 +56,9 @@ let clearIntervalSpy = jest
 const oneMinute = 60_000;
 const oneDayMinutes = 24 * 60;
 
-let server: InstanceType<InjectedFn["ExpressServer"]>;
+let server: InstanceType<InjectedFn["BotServer"]>;
 let requestHealthData: SpiedFunction<InjectedFn["requestHealthData"]>;
-let ExpressServer: InjectedFn["ExpressServer"];
+let BotServer: InjectedFn["BotServer"];
 let appVersion: InjectedFn["appVersion"];
 let httpsOptions: InjectedFn["httpsOptions"];
 let waiter: InstanceType<InjectedFn["WaiterForCalls"]>;
@@ -73,7 +73,7 @@ describe("[uptime daemon]", () => {
   beforeAll(async () => {
     const init = await injectDependencies();
     requestHealthData = jest.spyOn(init, "requestHealthData");
-    ExpressServer = init.ExpressServer;
+    BotServer = init.BotServer;
     appVersion = init.appVersion;
     httpsOptions = init.httpsOptions;
 
@@ -95,7 +95,7 @@ describe("[uptime daemon]", () => {
         waiter.tick();
       });
 
-    server = new ExpressServer(
+    server = new BotServer(
       appPort,
       enableSSL,
       appVersion,
@@ -125,7 +125,7 @@ describe("[uptime daemon]", () => {
 
     it("Failed to trigger the daemon if nextUrl is not set", async () => {
       const errMessage =
-        "Next node url is not set for this node. Unable to set up the daemon";
+        "Next instance url is not set for this node. Unable to set up the daemon";
       await expect(server.triggerDaemon("", 1)).rejects.toThrowError(
         errMessage,
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "ffmpeg-static": "5.2.0",
         "nanoid": "5.0.4",
         "newrelic": "11.9.0",
-        "ngrok": "4.3.3",
+        "ngrok": "5.0.0-beta.2",
         "node-telegram-bot-api": "0.64.0",
         "pg": "8.11.3",
         "picocolors": "1.0.0",
@@ -14000,15 +14000,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/listr2": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.0.0.tgz",
@@ -14892,32 +14883,26 @@
       }
     },
     "node_modules/ngrok": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-4.3.3.tgz",
-      "integrity": "sha512-a2KApnkiG5urRxBPdDf76nNBQTnNNWXU0nXw0SsqsPI+Kmt2lGf9TdVYpYrHMnC+T9KhcNSWjCpWqBgC6QcFvw==",
+      "version": "5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-5.0.0-beta.2.tgz",
+      "integrity": "sha512-UzsyGiJ4yTTQLCQD11k1DQaMwq2/SsztBg2b34zAqcyjS25qjDpogMKPaCKHwe/APRTHeel3iDXcVctk5CNaCQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@types/node": "^8.10.50",
         "extract-zip": "^2.0.1",
         "got": "^11.8.5",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^7.0.0 || ^8.0.0",
-        "yaml": "^1.10.0"
+        "yaml": "^2.2.2"
       },
       "bin": {
         "ngrok": "bin/ngrok"
       },
       "engines": {
-        "node": ">=10.19.0 <14 || >=14.2"
+        "node": ">=14.2"
       },
       "optionalDependencies": {
         "hpagent": "^0.1.2"
       }
-    },
-    "node_modules/ngrok/node_modules/@types/node": {
-      "version": "8.10.66",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -19177,11 +19162,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yaml-js": {
@@ -30141,12 +30126,6 @@
           "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
           "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
           "dev": true
-        },
-        "yaml": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-          "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-          "dev": true
         }
       }
     },
@@ -30822,24 +30801,16 @@
       }
     },
     "ngrok": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-4.3.3.tgz",
-      "integrity": "sha512-a2KApnkiG5urRxBPdDf76nNBQTnNNWXU0nXw0SsqsPI+Kmt2lGf9TdVYpYrHMnC+T9KhcNSWjCpWqBgC6QcFvw==",
+      "version": "5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-5.0.0-beta.2.tgz",
+      "integrity": "sha512-UzsyGiJ4yTTQLCQD11k1DQaMwq2/SsztBg2b34zAqcyjS25qjDpogMKPaCKHwe/APRTHeel3iDXcVctk5CNaCQ==",
       "requires": {
-        "@types/node": "^8.10.50",
         "extract-zip": "^2.0.1",
         "got": "^11.8.5",
         "hpagent": "^0.1.2",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^7.0.0 || ^8.0.0",
-        "yaml": "^1.10.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.66",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
-        }
+        "yaml": "^2.2.2"
       }
     },
     "nice-try": {
@@ -33979,9 +33950,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA=="
     },
     "yaml-js": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ffmpeg-static": "5.2.0",
     "nanoid": "5.0.4",
     "newrelic": "11.9.0",
-    "ngrok": "4.3.3",
+    "ngrok": "5.0.0-beta.2",
     "node-telegram-bot-api": "0.64.0",
     "pg": "8.11.3",
     "picocolors": "1.0.0",

--- a/src/scripts/dev.ts
+++ b/src/scripts/dev.ts
@@ -1,15 +1,12 @@
 import { Logger } from "../logger/index.js";
-import { ExpressServer } from "../server/express.js";
+import type { BotServer } from "../server/bot-server.js";
 import { getLaunchDelay } from "../common/timer.js";
 import { prepareInstance, prepareStopListener } from "../server/boot.js";
 import { flattenPromise } from "../common/helpers.js";
 
 const logger = new Logger("dev-script");
 
-const startServer = (
-  server: ExpressServer,
-  threadId: number,
-): Promise<void> => {
+const startServer = (server: BotServer, threadId: number): Promise<void> => {
   const launchDelay = getLaunchDelay(threadId);
   const stopListener = prepareStopListener();
 

--- a/src/scripts/start.ts
+++ b/src/scripts/start.ts
@@ -1,15 +1,12 @@
 import * as envy from "../env.js";
 import { Logger } from "../logger/index.js";
-import { ExpressServer } from "../server/express.js";
+import type { BotServer } from "../server/bot-server.js";
 import { getLaunchDelay } from "../common/timer.js";
 import { prepareInstance, prepareStopListener } from "../server/boot.js";
 
 const logger = new Logger("start-script");
 
-const startServer = (
-  server: ExpressServer,
-  threadId: number,
-): Promise<void> => {
+const startServer = (server: BotServer, threadId: number): Promise<void> => {
   const launchDelay = getLaunchDelay(threadId);
   const stopListener = prepareStopListener();
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,5 +1,5 @@
-import axios, { AxiosError } from "axios";
-import { HealthDto } from "./types.js";
+import axios, { type AxiosError } from "axios";
+import type { HealthDto } from "./types.js";
 
 class HealthError extends Error {
   public code = 0;

--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -1,5 +1,5 @@
 import * as envy from "../env.js";
-import { ExpressServer } from "./express.js";
+import { BotServer } from "./bot-server.js";
 import { httpsOptions } from "../../certs/index.js";
 import type { VoiceConverterOptions } from "../recognition/types.js";
 import {
@@ -19,8 +19,8 @@ import { isDBConfigValid } from "../db/utils.js";
 
 const logger = new Logger("boot-server");
 
-export const prepareInstance = (threadId: number): Promise<ExpressServer> => {
-  const server = new ExpressServer(
+export const prepareInstance = (threadId: number): Promise<BotServer> => {
+  const server = new BotServer(
     envy.appPort,
     envy.enableSSL,
     envy.appVersion,

--- a/src/server/tunnel.ts
+++ b/src/server/tunnel.ts
@@ -4,7 +4,7 @@ import { sSuffix } from "../text/utils.js";
 
 const logger = new Logger("tunnel");
 
-const createTunnel = (
+const createTunnel = async (
   port: number,
   enableSSL: boolean,
   token?: string,

--- a/src/testUtils/dependencies.ts
+++ b/src/testUtils/dependencies.ts
@@ -18,8 +18,8 @@ export const injectDependencies = async () => {
   const dbDurations = await import("../db/sql/durations.sql.js");
   const dbIgnoredChats = await import("../db/sql/ignoredchats.sql.js");
   const env = await import("../env.js");
-  const express = await import("../server/express.js");
-  const expressHelpers = await import("../server/api.js");
+  const server = await import("../server/bot-server.js");
+  const serverHelpers = await import("../server/api.js");
   const stripe = await import("../donate/stripe.js");
   const utils = await import("./waitFor.js");
   const emails = await import("../db/emails.js");
@@ -51,10 +51,10 @@ export const injectDependencies = async () => {
     ...dbDurations,
     ...dbIgnoredChats,
     ...env,
-    ...express,
+    ...server,
     ...donations,
     ...stripe,
-    ...expressHelpers,
+    ...serverHelpers,
     ...utils,
     ...emails,
     ...nodes,


### PR DESCRIPTION
Make the server name framework-agnostic. This essentially needed while migrating to fastify. Change the module names, change the log messages, rename variables