### PR TITLE
fix(fastify): Fastify - use the selfUrl as a host?

### DIFF
--- a/src/server/bot-server-base.ts
+++ b/src/server/bot-server-base.ts
@@ -1,0 +1,18 @@
+import { UptimeDaemon } from "./uptime.js";
+import { Logger } from "../logger/index.js";
+
+const logger = new Logger("server");
+
+export class BotServerBase {
+  protected readonly uptimeDaemon: UptimeDaemon;
+
+  constructor(
+    protected readonly serverName: string,
+    protected readonly port: number,
+    protected readonly version: string,
+  ) {
+    logger.info(`Initializing ${Logger.y(this.serverName)} bot server`);
+
+    this.uptimeDaemon = new UptimeDaemon(version);
+  }
+}

--- a/src/server/bot-server.ts
+++ b/src/server/bot-server.ts
@@ -3,9 +3,9 @@ import { createServer as createHttps } from "node:https";
 import express, { type Response } from "express";
 import { Logger } from "../logger/index.js";
 import { sSuffix } from "../text/utils.js";
-import { UptimeDaemon } from "./uptime.js";
-import { flattenPromise } from "../common/helpers.js";
+import { BotServerBase } from "./bot-server-base.js";
 import { AnalyticsData } from "../analytics/ga/types.js";
+import { flattenPromise } from "../common/helpers.js";
 import { collectAnalytics } from "../analytics/index.js";
 import { TgUpdateSchema } from "../telegram/api/types.js";
 import { initSentry, trackAPIHandlers } from "../monitoring/sentry.js";
@@ -21,9 +21,8 @@ import type { VoidPromise } from "../common/types.js";
 
 const logger = new Logger("server");
 
-export class BotServer implements BotServerModel {
+export class BotServer extends BotServerBase implements BotServerModel {
   private readonly app = express();
-  private readonly uptimeDaemon: UptimeDaemon;
 
   private stat: ServerStatCore | null = null;
   private bots: TelegramBotModel[] = [];
@@ -31,17 +30,13 @@ export class BotServer implements BotServerModel {
   private selfUrl = "";
   private threadId = 0;
 
-  public readonly serverName = "ExpressJS";
-
   constructor(
-    private readonly port: number,
-    private readonly version: string,
+    port: number,
+    version: string,
     private readonly webhookDoNotWait: boolean,
     private readonly httpsOptions?: HttpsOptions,
   ) {
-    logger.info("Initializing the bot server server");
-
-    this.uptimeDaemon = new UptimeDaemon(version);
+    super("ExpressJS", port, version);
 
     initSentry(this.app);
     trackAPIHandlers(this.app);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -6,7 +6,6 @@ export type ServerStatCore = ReturnType<typeof getDb>;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BotServerModel {
-  readonly serverName: string;
   start(): Promise<VoidPromise | VoidFunction>;
   applyHostLocation(launchDelay?: number): Promise<void>;
   triggerDaemon(


### PR DESCRIPTION
Fastify server can not establish the connection, perhaps it uses localhost instead of real host name. Lets try and specify the real host url