### PR TITLE
fix(sentry): Handle deleted files in the storage stat

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,6 +17,10 @@ module.exports = {
     "prettier",
   ],
   rules: {
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      { fixStyle: "inline-type-imports" },
+    ],
     "@typescript-eslint/consistent-type-definitions": ["error", "type"],
     "@typescript-eslint/prefer-nullish-coalescing": "off",
     "@typescript-eslint/no-misused-promises": "off",

--- a/e2e/dm.en.spec.ts
+++ b/e2e/dm.en.spec.ts
@@ -12,10 +12,10 @@ import request from "supertest";
 import nock from "nock";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import {
-  InjectedTestFn,
+  type InjectedTestFn,
   injectTestDependencies,
 } from "./helpers/dependencies.js";
 import { mockTableCreation, Pool as MockPool } from "../src/db/__mocks__/pg.js";

--- a/e2e/dm.ru.spec.ts
+++ b/e2e/dm.ru.spec.ts
@@ -12,10 +12,10 @@ import request from "supertest";
 import nock from "nock";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import {
-  InjectedTestFn,
+  type InjectedTestFn,
   injectTestDependencies,
 } from "./helpers/dependencies.js";
 import { mockTableCreation, Pool as MockPool } from "../src/db/__mocks__/pg.js";

--- a/e2e/donate.spec.ts
+++ b/e2e/donate.spec.ts
@@ -13,10 +13,10 @@ import request from "supertest";
 import { mockTableCreation, Pool as MockPool } from "../src/db/__mocks__/pg.js";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import {
-  InjectedTestFn,
+  type InjectedTestFn,
   injectTestDependencies,
 } from "./helpers/dependencies.js";
 import type { TgChatType } from "../src/telegram/api/types.js";

--- a/e2e/errors.spec.ts
+++ b/e2e/errors.spec.ts
@@ -11,7 +11,7 @@ import request from "supertest";
 import nock from "nock";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import { injectTestDependencies } from "./helpers/dependencies.js";
 import { Pool as MockPool } from "../src/db/__mocks__/pg.js";

--- a/e2e/group.en.spec.ts
+++ b/e2e/group.en.spec.ts
@@ -12,10 +12,10 @@ import {
 } from "@jest/globals";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import {
-  InjectedTestFn,
+  type InjectedTestFn,
   injectTestDependencies,
 } from "./helpers/dependencies.js";
 import { mockTableCreation, Pool as MockPool } from "../src/db/__mocks__/pg.js";

--- a/e2e/group.ru.spec.ts
+++ b/e2e/group.ru.spec.ts
@@ -12,10 +12,10 @@ import {
 } from "@jest/globals";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import {
-  InjectedTestFn,
+  type InjectedTestFn,
   injectTestDependencies,
 } from "./helpers/dependencies.js";
 import { mockTableCreation, Pool as MockPool } from "../src/db/__mocks__/pg.js";

--- a/e2e/health.spec.ts
+++ b/e2e/health.spec.ts
@@ -13,10 +13,10 @@ import { Pool as MockPool } from "../src/db/__mocks__/pg.js";
 import { HealthSsl, HealthStatus } from "../src/server/types.js";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import {
-  InjectedTestFn,
+  type InjectedTestFn,
   injectTestDependencies,
 } from "./helpers/dependencies.js";
 import type { VoidPromise } from "../src/common/types.js";

--- a/e2e/ignore.spec-ignored.ts
+++ b/e2e/ignore.spec-ignored.ts
@@ -12,10 +12,10 @@ import request from "supertest";
 import nock from "nock";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import {
-  InjectedTestFn,
+  type InjectedTestFn,
   injectTestDependencies,
 } from "./helpers/dependencies.js";
 import { mockTableCreation, Pool as MockPool } from "../src/db/__mocks__/pg.js";

--- a/e2e/lifecycle.spec.ts
+++ b/e2e/lifecycle.spec.ts
@@ -12,11 +12,11 @@ import nock from "nock";
 import { Pool as MockPool } from "../src/db/__mocks__/pg.js";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
 import {
   injectTestDependencies,
-  InjectedTestFn,
+  type InjectedTestFn,
 } from "./helpers/dependencies.js";
 import { HealthSsl, HealthStatus } from "../src/server/types.js";
 import type { VoidPromise } from "../src/common/types.js";

--- a/e2e/requests/db/botStat.ts
+++ b/e2e/requests/db/botStat.ts
@@ -2,9 +2,9 @@ import { expect } from "@jest/globals";
 import type { LanguageCode } from "../../../src/recognition/types.js";
 import { BotStatRecordModel } from "../../helpers.js";
 import { randomIntFromInterval } from "../../../src/common/timer.js";
-import { Pool as MockPool } from "../../../src/db/__mocks__/pg.js";
+import { type Pool as MockPool } from "../../../src/db/__mocks__/pg.js";
 import { UsagesSql } from "../../../src/db/sql/usages.sql.js";
-import { UsageRowScheme } from "../../../src/db/sql/usages.js";
+import { type UsageRowScheme } from "../../../src/db/sql/usages.js";
 
 export const mockGetBotStatItem = (
   pool: MockPool,

--- a/e2e/requests/db/donationStat.ts
+++ b/e2e/requests/db/donationStat.ts
@@ -1,9 +1,9 @@
-import { Pool as MockPool } from "../../../src/db/__mocks__/pg.js";
-import { BotStatRecordModel } from "../../helpers.js";
+import { type Pool as MockPool } from "../../../src/db/__mocks__/pg.js";
+import { type BotStatRecordModel } from "../../helpers.js";
 import { DonationsSql } from "../../../src/db/sql/donations.sql.js";
 import { expect } from "@jest/globals";
 import {
-  DonationRowScheme,
+  type DonationRowScheme,
   DonationStatus,
 } from "../../../src/db/sql/donations.js";
 

--- a/e2e/requests/db/ignoredChatsDb.ts
+++ b/e2e/requests/db/ignoredChatsDb.ts
@@ -1,5 +1,5 @@
 // import { expect } from "@jest/globals";
-import { Pool as MockPool } from "../../../src/db/__mocks__/pg.js";
+import { type Pool as MockPool } from "../../../src/db/__mocks__/pg.js";
 // import { IgnoredChatsSql } from "../../../src/db/sql/ignoredchats.sql.js";
 // import type { IgnoredChatRowScheme } from "../../../src/db/sql/ignoredchats.js";
 

--- a/e2e/requests/telegram.ts
+++ b/e2e/requests/telegram.ts
@@ -1,14 +1,14 @@
 import { resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect } from "@jest/globals";
-import request from "supertest";
-import nock from "nock";
+import type request from "supertest";
+import type nock from "nock";
 import querystring from "query-string";
-import { TelegramBotModel } from "../../src/telegram/bot.js";
+import { type TelegramBotModel } from "../../src/telegram/bot.js";
 import {
-  TelegramMessageMetaItem,
+  type TelegramMessageMetaItem,
   TelegramMessageMetaType,
-  TelegramMessageModel,
+  type TelegramMessageModel,
 } from "../helpers.js";
 import { getTranslator, isTranslationKey } from "../../src/text/index.js";
 import { type TranslationKey, TranslationKeys } from "../../src/text/types.js";

--- a/e2e/scheduler.spec.ts
+++ b/e2e/scheduler.spec.ts
@@ -9,9 +9,13 @@ import {
 } from "@jest/globals";
 import {
   injectDependencies,
-  InjectedFn,
+  type InjectedFn,
 } from "../src/testUtils/dependencies.js";
-import { HealthDto, HealthSsl, HealthStatus } from "../src/server/types.js";
+import {
+  type HealthDto,
+  HealthSsl,
+  HealthStatus,
+} from "../src/server/types.js";
 import type { SpiedFunction } from "jest-mock";
 import type { VoidPromise } from "../src/common/types.js";
 

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -1,7 +1,7 @@
 import { Logger } from "../logger/index.js";
 import { collectEvents as collectGA } from "./ga/index.js";
 import { collectEvents as collectAmplitude } from "./amplitude/index.js";
-import { AnalyticsData } from "./ga/types.js";
+import { type AnalyticsData } from "./ga/types.js";
 
 const logger = new Logger("analytics");
 

--- a/src/db/__mocks__/pg.ts
+++ b/src/db/__mocks__/pg.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import pg from "pg";
+import type pg from "pg";
 import { nanoid } from "nanoid";
 import { NodesSql } from "../sql/nodes.sql.js";
 import { UsagesSql } from "../sql/usages.sql.js";

--- a/src/db/donations.spec.ts
+++ b/src/db/donations.spec.ts
@@ -8,7 +8,10 @@ import {
   jest,
 } from "@jest/globals";
 import { Pool as MockPool } from "./__mocks__/pg.js";
-import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
+import {
+  injectDependencies,
+  type InjectedFn,
+} from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",

--- a/src/db/durations.ts
+++ b/src/db/durations.ts
@@ -1,6 +1,6 @@
 import type { Pool } from "pg";
 import { Logger } from "../logger/index.js";
-import { DurationRowScheme, DurationsDb } from "./sql/durations.js";
+import { type DurationRowScheme, DurationsDb } from "./sql/durations.js";
 
 const logger = new Logger("postgres-durations");
 

--- a/src/db/emails.spec.ts
+++ b/src/db/emails.spec.ts
@@ -8,7 +8,10 @@ import {
   beforeAll,
 } from "@jest/globals";
 import { Pool as MockPool } from "./__mocks__/pg.js";
-import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
+import {
+  injectDependencies,
+  type InjectedFn,
+} from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",

--- a/src/db/nodes.spec.ts
+++ b/src/db/nodes.spec.ts
@@ -8,7 +8,10 @@ import {
   beforeAll,
 } from "@jest/globals";
 import { Pool as MockPool } from "./__mocks__/pg.js";
-import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
+import {
+  injectDependencies,
+  type InjectedFn,
+} from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",

--- a/src/db/usages.spec.ts
+++ b/src/db/usages.spec.ts
@@ -8,7 +8,10 @@ import {
   jest,
 } from "@jest/globals";
 import { Pool as MockPool } from "./__mocks__/pg.js";
-import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
+import {
+  injectDependencies,
+  type InjectedFn,
+} from "../testUtils/dependencies.js";
 import type { LanguageCode } from "../recognition/types.js";
 
 jest.unstable_mockModule(

--- a/src/donate/stripe.ts
+++ b/src/donate/stripe.ts
@@ -1,4 +1,4 @@
-import { PaymentService } from "./types.js";
+import { type PaymentService } from "./types.js";
 
 export class StripePayment implements PaymentService {
   public readonly isReady: boolean = false;

--- a/src/logger/integration.ts
+++ b/src/logger/integration.ts
@@ -1,9 +1,9 @@
 import { createLogger, format, transports } from "winston";
 import stripAnsi from "strip-ansi";
 import Logsene from "winston-logsene";
-import { isAxiosError, AxiosError } from "axios";
+import { isAxiosError, type AxiosError } from "axios";
 import { selfUrl, logApiTokenV2, appVersion, isDebug } from "../env.js";
-import { LogType, SANITIZE_CHARACTER } from "./const.js";
+import { type LogType, SANITIZE_CHARACTER } from "./const.js";
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 const convertDataItem = (data: any, ind: number): Record<string, string> => {

--- a/src/scheduler/scheduler.spec.ts
+++ b/src/scheduler/scheduler.spec.ts
@@ -8,7 +8,10 @@ import {
   beforeAll,
 } from "@jest/globals";
 import { nanoid } from "nanoid";
-import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
+import {
+  injectDependencies,
+  type InjectedFn,
+} from "../testUtils/dependencies.js";
 import type { Mock } from "jest-mock";
 import type { VoidPromise } from "../common/types.js";
 

--- a/src/server/api.spec.ts
+++ b/src/server/api.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest } from "@jest/globals";
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { type AxiosRequestConfig } from "axios";
 import { requestHealthData } from "./api.js";
-import { HealthDto, HealthSsl, HealthStatus } from "./types.js";
+import { type HealthDto, HealthSsl, HealthStatus } from "./types.js";
 
 const mockRequest = (
   fn: (config?: AxiosRequestConfig) => Promise<HealthDto>,

--- a/src/server/tunnel.spec.ts
+++ b/src/server/tunnel.spec.ts
@@ -1,5 +1,8 @@
 import { it, describe, expect, jest, beforeAll } from "@jest/globals";
-import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
+import {
+  injectDependencies,
+  type InjectedFn,
+} from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",

--- a/src/statistic/cache.spec.ts
+++ b/src/statistic/cache.spec.ts
@@ -1,5 +1,8 @@
 import { expect, describe, it, jest, beforeAll } from "@jest/globals";
-import { injectDependencies, InjectedFn } from "../testUtils/dependencies.js";
+import {
+  injectDependencies,
+  type InjectedFn,
+} from "../testUtils/dependencies.js";
 
 jest.unstable_mockModule(
   "../logger/index",
@@ -24,7 +27,7 @@ const testData3 = "some-test-data-3";
 const item3: TestCacheData = { testId: testId3, testData: testData3 };
 
 let cacheSize = 0;
-let CacheProvider: Awaited<typeof import("./cache.js").CacheProvider>;
+let CacheProvider: InjectedFn["CacheProvider"];
 let cache: InstanceType<InjectedFn["CacheProvider"]>;
 
 describe("[cache]", () => {

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -7,6 +7,16 @@ import { collectEvents } from "../analytics/amplitude/index.js";
 
 const logger = new Logger("storage");
 
+const safeSize = (path: string): number => {
+  try {
+    const { size } = statSync(path);
+    return size;
+  } catch (err) {
+    // The file was most likely deleted, hence 0
+    return 0;
+  }
+};
+
 export const printCurrentStorageUsage = async (
   dir: string,
 ): Promise<number> => {
@@ -17,7 +27,7 @@ export const printCurrentStorageUsage = async (
         (file) => !file.includes("gitkeep"),
       );
       const cacheSizeBytes = files.reduce(
-        (sum, file) => sum + statSync(resolvePath(folder, file)).size,
+        (sum, file) => sum + safeSize(resolvePath(folder, file)),
         0,
       );
       const cacheSizeMBytes = Math.ceil(cacheSizeBytes / getMB(1));

--- a/src/telegram/actions/ignore.ts
+++ b/src/telegram/actions/ignore.ts
@@ -1,7 +1,7 @@
 import { GenericAction } from "./common.js";
 import { Logger } from "../../logger/index.js";
 import { collectAnalytics } from "../../analytics/index.js";
-import { TelegramMessagePrefix, type BotMessageModel } from "../types.js";
+import { type TelegramMessagePrefix, type BotMessageModel } from "../types.js";
 import type { TgMessage } from "../api/types.js";
 
 const logger = new Logger("telegram-bot");

--- a/src/telegram/actions/voice.ts
+++ b/src/telegram/actions/voice.ts
@@ -2,7 +2,10 @@ import { GenericAction } from "./common.js";
 import { isVoiceMessage } from "../helpers.js";
 import { Logger } from "../../logger/index.js";
 import { TranslationKeys } from "../../text/types.js";
-import { type LanguageCode, VoiceConverter } from "../../recognition/types.js";
+import {
+  type LanguageCode,
+  type VoiceConverter,
+} from "../../recognition/types.js";
 import { collectAnalytics } from "../../analytics/index.js";
 import { TimeMeasure } from "../../common/timer.js";
 import { isBlockedByUser } from "../api/tgerror.js";

--- a/src/telegram/api/tgapi.spec.ts
+++ b/src/telegram/api/tgapi.spec.ts
@@ -1,23 +1,23 @@
 import axios, {
   AxiosHeaders,
-  AxiosError,
-  AxiosRequestConfig,
-  CreateAxiosDefaults,
+  type AxiosError,
+  type AxiosRequestConfig,
+  type CreateAxiosDefaults,
 } from "axios";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { nanoid } from "nanoid";
 import {
-  BotCommandDto,
-  TgCore,
-  TgFile,
-  TgInlineKeyboardButton,
-  TgInvoice,
-  TgLeaveChatSchema,
-  TgMessage,
-  TgWebHook,
+  type BotCommandDto,
+  type TgCore,
+  type TgFile,
+  type TgInlineKeyboardButton,
+  type TgInvoice,
+  type TgLeaveChatSchema,
+  type TgMessage,
+  type TgWebHook,
 } from "./types.js";
 import { TelegramApi } from "./tgapi.js";
-import { TgError } from "./tgerror.js";
+import { type TgError } from "./tgerror.js";
 import { SANITIZE_CHARACTER } from "../../logger/const.js";
 
 const getApiResponse = <Response>(

--- a/src/telegram/api/tgapi.ts
+++ b/src/telegram/api/tgapi.ts
@@ -1,22 +1,22 @@
-import axios, { AxiosError, AxiosInstance } from "axios";
-import { z } from "zod";
+import axios, { type AxiosError, type AxiosInstance } from "axios";
+import { type z } from "zod";
 import {
-  ApiErrorReflector,
-  BotCommandDto,
-  BotCommandListDto,
-  EditMessageDto,
-  FileDto,
-  InvoiceDto,
-  MessageDto,
-  PreCheckoutQueryDto,
-  TgCore,
-  TgFile,
-  TgInvoice,
+  type ApiErrorReflector,
+  type BotCommandDto,
+  type BotCommandListDto,
+  type EditMessageDto,
+  type FileDto,
+  type InvoiceDto,
+  type MessageDto,
+  type PreCheckoutQueryDto,
+  type TgCore,
+  type TgFile,
+  type TgInvoice,
   TgLeaveChatSchema,
-  TgMessage,
-  TgMessageOptions,
+  type TgMessage,
+  type TgMessageOptions,
   TgSetWebHookSchema,
-  TgWebHook,
+  type TgWebHook,
   TgWebHookSchema,
 } from "./types.js";
 import { TgError } from "./tgerror.js";

--- a/src/telegram/api/tgerror.spec.ts
+++ b/src/telegram/api/tgerror.spec.ts
@@ -6,7 +6,7 @@ import {
   isMessageNotModified,
   isKickedFromSupergroup,
 } from "./tgerror.js";
-import { TgCore } from "./types.js";
+import { type TgCore } from "./types.js";
 import { SANITIZE_CHARACTER } from "../../logger/const.js";
 
 describe("tgerror", () => {

--- a/src/telegram/api/tgerror.ts
+++ b/src/telegram/api/tgerror.ts
@@ -1,4 +1,4 @@
-import { TgCore } from "./types.js";
+import { type TgCore } from "./types.js";
 import { SANITIZE_CHARACTER } from "../../logger/const.js";
 import { getRegExpFromString } from "../../common/helpers.js";
 

--- a/src/telegram/api/types.ts
+++ b/src/telegram/api/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Prettify } from "../../common/types.js";
+import { type Prettify } from "../../common/types.js";
 
 export type ApiErrorReflector = (err: unknown) => Promise<void>;
 

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,11 +1,11 @@
 import {
-  TgCallbackQuery,
-  TgCheckoutQuery,
-  TgMessage,
-  TgUpdate,
+  type TgCallbackQuery,
+  type TgCheckoutQuery,
+  type TgMessage,
+  type TgUpdate,
 } from "./api/types.js";
 import { Logger } from "../logger/index.js";
-import { VoiceConverter } from "../recognition/types.js";
+import { type VoiceConverter } from "../recognition/types.js";
 import { TranslationKeys } from "../text/types.js";
 import { BotMessageModel, TelegramMessagePrefix } from "./types.js";
 import { isMessageSupported } from "./helpers.js";
@@ -15,8 +15,8 @@ import { BotActions } from "./actions/index.js";
 import { getBotMenuCommands } from "./data.js";
 import { TelegramApi } from "./api/tgapi.js";
 import { collectAnalytics } from "../analytics/index.js";
-import { AnalyticsData } from "../analytics/ga/types.js";
-import { PaymentService } from "../donate/types.js";
+import { type AnalyticsData } from "../analytics/ga/types.js";
+import { type PaymentService } from "../donate/types.js";
 import { initTgReflector } from "./reflector.js";
 import type { getDb } from "../db/index.js";
 

--- a/src/telegram/helpers.spec.ts
+++ b/src/telegram/helpers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { TgMessage } from "./api/types.js";
+import { type TgMessage } from "./api/types.js";
 import { getUserLanguage, getLanguageByText } from "./helpers.js";
 import { DEFAULT_LANGUAGE, type LanguageCode } from "../recognition/types.js";
 

--- a/src/telegram/helpers.ts
+++ b/src/telegram/helpers.ts
@@ -1,14 +1,18 @@
 import {
   BotCommand,
-  BotMessageModel,
-  DonationDto,
-  DonationPayload,
+  type BotMessageModel,
+  type DonationDto,
+  type DonationPayload,
   DonationSchema,
   VoiceContentReason,
   VoiceContentReasonModel,
 } from "./types.js";
 import { telegramBotName } from "../env.js";
-import { TgCallbackQuery, TgMedia, TgMessage } from "./api/types.js";
+import {
+  type TgCallbackQuery,
+  type TgMedia,
+  type TgMessage,
+} from "./api/types.js";
 import {
   DEFAULT_LANGUAGE,
   type LanguageCode,

--- a/src/telegram/reflector.ts
+++ b/src/telegram/reflector.ts
@@ -1,7 +1,7 @@
 import { Logger } from "../logger/index.js";
 import { TelegramApi } from "./api/tgapi.js";
 import { hasNoRightsToSendMessage, TgError } from "./api/tgerror.js";
-import { ApiErrorReflector } from "./api/types.js";
+import { type ApiErrorReflector } from "./api/types.js";
 
 const logger = new Logger("telegram:reflector");
 

--- a/src/telegram/types.ts
+++ b/src/telegram/types.ts
@@ -15,8 +15,8 @@ import {
 } from "./helpers.js";
 import { Logger } from "../logger/index.js";
 import { getTranslator } from "../text/index.js";
-import { TgMessage, TgMessageOptions } from "./api/types.js";
-import { AnalyticsData } from "../analytics/ga/types.js";
+import { type TgMessage, type TgMessageOptions } from "./api/types.js";
+import { type AnalyticsData } from "../analytics/ga/types.js";
 import type { LanguageCode } from "../recognition/types.js";
 
 export enum VoiceContentReason {

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -1,4 +1,4 @@
-import { TranslationKey, TranslationKeys } from "./types.js";
+import { type TranslationKey, TranslationKeys } from "./types.js";
 import {
   DEFAULT_LANGUAGE,
   SUPPORTED_LANGUAGES,

--- a/src/whisper/whisper-engine.ts
+++ b/src/whisper/whisper-engine.ts
@@ -3,11 +3,17 @@ import { join as joinPath } from "node:path";
 import type { LanguageCode } from "../recognition/types.js";
 import getWhisper from "./whisper-addon.cjs";
 
+type WhisperSupportedLanguage =
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  import("./whisper-addon.cjs").WhisperSupportedLanguage;
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type WhisperOptions = import("./whisper-addon.cjs").WhisperOptions;
+
 const CURRENT_DIR = fileURLToPath(new URL(".", import.meta.url));
 
 const mapAppLanguageToWhisperLanguage = (
   languageCode: LanguageCode,
-): import("./whisper-addon.cjs").WhisperSupportedLanguage => {
+): WhisperSupportedLanguage => {
   switch (languageCode) {
     case "ru-RU":
       return "ru";
@@ -38,12 +44,12 @@ export const runWhisper = async (
 ): Promise<string> => {
   const modelPath = joinPath(
     CURRENT_DIR,
-    "./ggml-model-whisper-small-q5_1.bin",
+    "./generated/ggml-model-whisper-large-q5_0.bin",
   );
   const runWhisperAsync = getWhisper();
   const language = mapAppLanguageToWhisperLanguage(languageCode);
 
-  const whisperParams: import("./whisper-addon.cjs").WhisperOptions = {
+  const whisperParams: WhisperOptions = {
     language,
     model: modelPath,
     fname_inp: wavPath,


### PR DESCRIPTION
Storage stat script fails when the file gets deleted from the temp folder. It is wrapped into try/catch already, But handling each file properly will unlock sending events into the analytics system

fixes sentry `ENOENT: no such file or directory, stat '/usr/src/app/file-temp/RdvWNR2NiF_file_5739097.oga'`