### PR TITLE
fix(classes): Put properties outside the constructor

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -27,6 +27,9 @@ type UserNameOptions = {
 export class TelegramMessageModel {
   public messageId = 0;
   public voiceId = "";
+  public readonly chatId: number;
+  public readonly chatType: TgChatType;
+
   private text = "";
   private voiceDuration = 0;
   private callbackData = "";
@@ -39,10 +42,10 @@ export class TelegramMessageModel {
   private contentType: "voice" | "audio" | "video_note" = "voice";
   private mimeType = "";
 
-  constructor(
-    public readonly chatId: number,
-    public readonly chatType: TgChatType,
-  ) {}
+  constructor(chatId: number, chatType: TgChatType) {
+    this.chatId = chatId;
+    this.chatType = chatType;
+  }
 
   public setName(
     messageId: number,
@@ -209,23 +212,35 @@ export const TelegramMessageMetaType = {
 type TelegramMessageMeta = ValueOf<typeof TelegramMessageMetaType>;
 
 export class TelegramMessageMetaItem {
+  public readonly type: TelegramMessageMeta;
+  public readonly title: string;
+  public readonly data: string;
+  public readonly btnType: TelegramButtonType;
+
   constructor(
-    public readonly type: TelegramMessageMeta,
-    public readonly title: string,
-    public readonly data: string,
-    public readonly btnType: TelegramButtonType = "d",
-  ) {}
+    type: TelegramMessageMeta,
+    title: string,
+    data: string,
+    btnType: TelegramButtonType = "d",
+  ) {
+    this.type = type;
+    this.title = title;
+    this.data = data;
+    this.btnType = btnType;
+  }
 }
 
 export class BotStatRecordModel {
   public objectId?: string;
   public user = "";
   public usageCount = 0;
+  public chatId: number;
+  public langId: LanguageCode;
 
-  constructor(
-    public chatId: number,
-    public langId: LanguageCode = "en-US",
-  ) {}
+  constructor(chatId: number, langId: LanguageCode = "en-US") {
+    this.chatId = chatId;
+    this.langId = langId;
+  }
 
   public setObjectId(objectId: number): this {
     this.objectId = String(objectId);

--- a/src/analytics/ga/types.ts
+++ b/src/analytics/ga/types.ts
@@ -67,6 +67,9 @@ type AnalyticsAction = BotCommandType | "/voice" | "/app" | "/ignore";
 
 export class AnalyticsData {
   private readonly timer: TimeMeasure;
+  private readonly appVersion: string;
+  private readonly url: string;
+  private readonly threadId: number;
   private events: AnalyticsEvent[] = [];
   private id = 0;
   private lang = defaultLang;
@@ -75,11 +78,10 @@ export class AnalyticsData {
   private commandMeta = "";
   private title = "Audio Message Bot";
 
-  constructor(
-    private readonly appVersion: string,
-    private readonly url: string,
-    private readonly threadId: number,
-  ) {
+  constructor(appVersion: string, url: string, threadId: number) {
+    this.appVersion = appVersion;
+    this.url = url;
+    this.threadId = threadId;
     this.timer = new TimeMeasure();
   }
 

--- a/src/db/__mocks__/pg.ts
+++ b/src/db/__mocks__/pg.ts
@@ -84,12 +84,18 @@ export const defaults = {
 
 class MockSql {
   public readonly id = nanoid();
+  public readonly sql: string;
+  public readonly handler: (
+    values: AnyTypeForMock[],
+  ) => Promise<AnyTypeForMock>;
+
   constructor(
-    public readonly sql: string,
-    public readonly handler: (
-      values: AnyTypeForMock[],
-    ) => Promise<AnyTypeForMock>,
-  ) {}
+    sql: string,
+    handler: (values: AnyTypeForMock[]) => Promise<AnyTypeForMock>,
+  ) {
+    this.sql = sql;
+    this.handler = handler;
+  }
 }
 
 export const mockTableCreation = (testPool: Pool) => {

--- a/src/db/sql/donations.ts
+++ b/src/db/sql/donations.ts
@@ -22,8 +22,11 @@ export type DonationRowScheme = {
 
 export class DonationsDb {
   private initialized = false;
+  private readonly pool: Pool;
 
-  constructor(private readonly pool: Pool) {}
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
 
   public async init(): Promise<void> {
     const query = DonationsSql.createTable;

--- a/src/db/sql/durations.ts
+++ b/src/db/sql/durations.ts
@@ -12,8 +12,11 @@ export type DurationRowScheme = {
 
 export class DurationsDb {
   private initialized = false;
+  private readonly pool: Pool;
 
-  constructor(private readonly pool: Pool) {}
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
 
   public async init(): Promise<void> {
     const query = DurationsSql.createTable;

--- a/src/db/sql/emails.ts
+++ b/src/db/sql/emails.ts
@@ -10,8 +10,11 @@ export type UsedEmailRowScheme = {
 
 export class UsedEmailDb {
   private initialized = false;
+  private readonly pool: Pool;
 
-  constructor(private readonly pool: Pool) {}
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
 
   public async init(): Promise<void> {
     const query = UsedEmailsSql.createTable;

--- a/src/db/sql/ignoredchats.ts
+++ b/src/db/sql/ignoredchats.ts
@@ -11,8 +11,11 @@ export type IgnoredChatsRowScheme = {
 
 export class IgnoredChatsDb {
   private initialized = false;
+  private readonly pool: Pool;
 
-  constructor(private readonly pool: Pool) {}
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
 
   public async init(): Promise<void> {
     const query = IgnoredChatsSql.createTable;

--- a/src/db/sql/nodes.ts
+++ b/src/db/sql/nodes.ts
@@ -13,8 +13,11 @@ export type NodeRowScheme = {
 
 export class NodesDb {
   private initialized = false;
+  private readonly pool: Pool;
 
-  constructor(private readonly pool: Pool) {}
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
 
   public async init(): Promise<void> {
     const query = NodesSql.createTable;

--- a/src/db/sql/usages.ts
+++ b/src/db/sql/usages.ts
@@ -14,8 +14,11 @@ export type UsageRowScheme = {
 
 export class UsagesDb {
   private initialized = false;
+  private readonly pool: Pool;
 
-  constructor(private readonly pool: Pool) {}
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
 
   public async init(): Promise<void> {
     const query = UsagesSql.createTable;

--- a/src/donate/stripe.ts
+++ b/src/donate/stripe.ts
@@ -2,8 +2,10 @@ import { type PaymentService } from "./types.js";
 
 export class StripePayment implements PaymentService {
   public readonly isReady: boolean = false;
+  private readonly token: string;
 
-  constructor(private readonly token: string) {
+  constructor(token: string) {
+    this.token = token;
     this.isReady = Boolean(token);
   }
 

--- a/src/logger/__mocks__/index.ts
+++ b/src/logger/__mocks__/index.ts
@@ -16,8 +16,11 @@ export class Logger {
   }
 
   private additionalPrefix = "";
+  private readonly id: string;
 
-  constructor(private readonly id = "") {}
+  constructor(id = "") {
+    this.id = id;
+  }
 
   public setAdditionalPrefix(prefix: string): void {
     this.additionalPrefix = prefix;

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -72,11 +72,10 @@ export class Logger {
 
   private readonly additionalPrefix: string;
   private readonly level: number;
+  private readonly id: string;
 
-  constructor(
-    private readonly id = "",
-    level = logLevel,
-  ) {
+  constructor(id = "", level = logLevel) {
+    this.id = id;
     const threadId = cluster.isMaster ? 0 : cluster?.worker?.id || 0;
     this.additionalPrefix = `thread-${threadId}`;
     const logType = LogLevelSchema.parse(level);

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -6,6 +6,8 @@ const logger = new Logger("daemon");
 export class ScheduleDaemon<TickData> {
   private readonly interval = 60_000;
   private readonly printId: string;
+  private readonly id: string;
+  private readonly onTick: () => Promise<TickData>;
   private handler: NodeJS.Timeout | null = null;
   private shouldStop?: (data: TickData) => boolean;
   private onFinish?: VoidPromise;
@@ -14,10 +16,9 @@ export class ScheduleDaemon<TickData> {
     return !!this.handler;
   }
 
-  constructor(
-    private readonly id: string,
-    private readonly onTick: () => Promise<TickData>,
-  ) {
+  constructor(id: string, onTick: () => Promise<TickData>) {
+    this.id = id;
+    this.onTick = onTick;
     this.printId = `[${this.id}]`;
   }
 

--- a/src/server/bot-server-base.ts
+++ b/src/server/bot-server-base.ts
@@ -18,13 +18,24 @@ export abstract class BotServerBase<ServerType> implements BotServerModelBase {
   protected nodeVersion = "";
   protected readonly isHttps: boolean;
 
+  protected readonly serverName: string;
+  protected readonly port: number;
+  protected readonly version: string;
+  protected readonly webhookDoNotWait: boolean;
+  protected readonly httpsOptions?: HttpsOptions;
+
   protected constructor(
-    protected readonly serverName: string,
-    protected readonly port: number,
-    protected readonly version: string,
-    protected readonly webhookDoNotWait: boolean,
-    protected readonly httpsOptions?: HttpsOptions,
+    serverName: string,
+    port: number,
+    version: string,
+    webhookDoNotWait: boolean,
+    httpsOptions?: HttpsOptions,
   ) {
+    this.serverName = serverName;
+    this.port = port;
+    this.version = version;
+    this.webhookDoNotWait = webhookDoNotWait;
+    this.httpsOptions = httpsOptions;
     logger.info(`Initializing ${Logger.y(this.serverName)} bot server`);
 
     this.isHttps = Boolean(httpsOptions);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -58,17 +58,25 @@ export type HealthSslType = ValueOf<typeof HealthSsl>;
 
 export class HealthModel {
   private readonly ssl: HealthSslType;
+  private readonly version: string;
+  private readonly threadId: number;
+  private readonly serverName: string;
+  private readonly coreVersion: string;
   private status: HealthStatusType = HealthStatus.InProgress;
   private message = "Waiting for bots to set up";
   private urls: string[] = [];
 
   constructor(
-    private readonly version: string,
+    version: string,
     isHttps: boolean,
-    private readonly threadId: number,
-    private readonly serverName: string,
-    private readonly coreVersion: string,
+    threadId: number,
+    serverName: string,
+    coreVersion: string,
   ) {
+    this.version = version;
+    this.threadId = threadId;
+    this.serverName = serverName;
+    this.coreVersion = coreVersion;
     this.ssl = isHttps ? HealthSsl.On : HealthSsl.Off;
   }
 

--- a/src/server/uptime.ts
+++ b/src/server/uptime.ts
@@ -11,6 +11,7 @@ const logger = new Logger("uptime");
 export class UptimeDaemon {
   private static readonly minLifecycleInterval = 1;
   private readonly daemon: ScheduleDaemon<void>;
+  private readonly version: string;
 
   private currentUrl = "";
   private nextUrl = "";
@@ -22,7 +23,8 @@ export class UptimeDaemon {
     return this.daemon.isRunning;
   }
 
-  constructor(private readonly version = "") {
+  constructor(version = "") {
+    this.version = version;
     this.daemon = new ScheduleDaemon("uptime", () =>
       this.onTick(),
     ).setStopHandler(

--- a/src/statistic/cache.ts
+++ b/src/statistic/cache.ts
@@ -5,11 +5,12 @@ const logger = new Logger("cache");
 
 export class CacheProvider<Data, UniqId extends keyof Data> {
   private cache: Data[] = [];
+  private readonly cacheSize: number;
+  private readonly idKey: UniqId;
 
-  constructor(
-    private readonly cacheSize: number,
-    private readonly idKey: UniqId,
-  ) {
+  constructor(cacheSize: number, idKey: UniqId) {
+    this.cacheSize = cacheSize;
+    this.idKey = idKey;
     if (!this.hasCacheEnabled()) {
       logger.warn(
         `Cache size is ${Logger.y(

--- a/src/telegram/actions/common.ts
+++ b/src/telegram/actions/common.ts
@@ -20,10 +20,13 @@ const logger = new Logger("telegram-bot");
 export abstract class GenericAction {
   protected readonly text = getTranslator();
 
-  constructor(
-    protected readonly stat: ReturnType<typeof getDb>,
-    protected readonly bot: TelegramApi,
-  ) {}
+  protected readonly stat: ReturnType<typeof getDb>;
+  protected readonly bot: TelegramApi;
+
+  constructor(stat: ReturnType<typeof getDb>, bot: TelegramApi) {
+    this.stat = stat;
+    this.bot = bot;
+  }
 
   public abstract runAction(
     mdl: BotMessageModel,

--- a/src/telegram/api/tgapi.ts
+++ b/src/telegram/api/tgapi.ts
@@ -30,11 +30,13 @@ export class TelegramApi {
   private static readonly path = "bot";
 
   private readonly client: AxiosInstance;
+  private readonly apiToken: string;
+  private readonly errorReflector?: ApiErrorReflector;
 
-  constructor(
-    private readonly apiToken: string,
-    private readonly errorReflector?: ApiErrorReflector,
-  ) {
+  constructor(apiToken: string, errorReflector?: ApiErrorReflector) {
+    this.apiToken = apiToken;
+    this.errorReflector = errorReflector;
+
     this.client = axios.create({
       method: "POST",
       baseURL: TelegramApi.url,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -25,15 +25,17 @@ const logger = new Logger("telegram-bot");
 export class TelegramBotModel {
   private readonly bot: TelegramApi;
   private readonly actions: BotActions;
+  private readonly token: string;
   private id = "";
   private host = "";
   private path = "";
 
   constructor(
-    private readonly token: string,
+    token: string,
     converter: VoiceConverter,
     stat: ReturnType<typeof getDb>,
   ) {
+    this.token = token;
     const reflector = initTgReflector(this.token);
     this.bot = new TelegramApi(this.token, reflector);
     this.actions = new BotActions(stat, this.bot);

--- a/src/telegram/types.ts
+++ b/src/telegram/types.ts
@@ -30,10 +30,13 @@ export const VoiceContentReason = {
 export type VoiceContentReasonType = ValueOf<typeof VoiceContentReason>;
 
 export class VoiceContentReasonModel {
-  constructor(
-    public readonly type: VoiceContentReasonType,
-    public readonly info?: string | number,
-  ) {}
+  public readonly type: VoiceContentReasonType;
+  public readonly info?: string | number;
+
+  constructor(type: VoiceContentReasonType, info?: string | number) {
+    this.type = type;
+    this.info = info;
+  }
 }
 
 export const BotCommand = {
@@ -93,10 +96,13 @@ export type MessageOptions = {
 };
 
 export class TelegramMessagePrefix {
-  constructor(
-    public readonly chatId: number,
-    public readonly id = nanoid(10),
-  ) {}
+  public readonly chatId: number;
+  public readonly id: string;
+
+  constructor(chatId: number, id = nanoid(10)) {
+    this.chatId = chatId;
+    this.id = id;
+  }
 
   public getPrefix(): string {
     return `[Id=${Logger.y(this.id)}] [ChatId=${Logger.y(this.chatId)}]`;
@@ -104,16 +110,21 @@ export class TelegramMessagePrefix {
 }
 
 export class BotLangData {
-  constructor(
-    public readonly langId: LanguageCode,
-    public readonly prefix: TelegramMessagePrefix,
-  ) {}
+  public readonly langId: LanguageCode;
+  public readonly prefix: TelegramMessagePrefix;
+
+  constructor(langId: LanguageCode, prefix: TelegramMessagePrefix) {
+    this.langId = langId;
+    this.prefix = prefix;
+  }
 }
 
 export class BotCommandOption {
   public readonly description: string;
+  public readonly command: BotCommandType;
 
-  constructor(public readonly command: BotCommandType) {
+  constructor(command: BotCommandType) {
+    this.command = command;
     const translator = getTranslator();
     this.description = translator.menu(command);
   }
@@ -147,11 +158,15 @@ export class TelegramButtonModel<V extends string = string> {
     }
   }
 
-  constructor(
-    public readonly id: TelegramButtonType,
-    public readonly value: V,
-    public readonly logPrefix: string,
-  ) {}
+  public readonly id: TelegramButtonType;
+  public readonly value: V;
+  public readonly logPrefix: string;
+
+  constructor(id: TelegramButtonType, value: V, logPrefix: string) {
+    this.id = id;
+    this.value = value;
+    this.logPrefix = logPrefix;
+  }
 
   public getDtoString(): string {
     const dto: BotButtonDto = {


### PR DESCRIPTION
Node flag --strip-type-definitions does not allow any custom Typescript specific syntax, such as enums and in-constructor property declarations. I refactor constructors in scope of this commit