### PR TITLE
fix(sentry): Fix the release inconsistency in CI 

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     secrets: inherit
     with:
-      version: ${{ needs.prerelease.outputs.version }}
+      version: v${{ needs.prerelease.outputs.version }}
       sha: ${{ github.sha }}
       # Enable if you want to test on one environment
       servers: '["Production β"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,5 @@ jobs:
     uses: ./.github/workflows/docker.yml
     secrets: inherit
     with:
-      version: 0.0.0-${{ github.event.pull_request.head.sha }}
+      version: v0.0.0-${{ github.event.pull_request.head.sha }}
       sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/deploy-trigger.yml
+++ b/.github/workflows/deploy-trigger.yml
@@ -12,7 +12,7 @@ on:
         required: true
       version:
         type: string
-        description: "Version tag in format: v1.0.0 or commit sha"
+        description: "Version tag in format: 1.0.0 (no v prefix!) or commit sha"
         required: true
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/heroku.yml
     secrets: inherit
     with:
-      version: ${{ inputs.version }}
+      version: v${{ inputs.version }}
       servers: '["${{ inputs.server }}"]'
 
   post-trigger:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
         required: false
       version:
         type: string
-        description: "Version tag"
+        description: "Version tag (ie v1.0.0)"
         required: true
       sha:
         type: string
@@ -31,5 +31,5 @@ jobs:
     uses: ./.github/workflows/heroku.yml
     secrets: inherit
     with:
-      version: v${{ inputs.version }}
+      version: ${{ inputs.version }}
       servers: ${{ inputs.servers }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     outputs:
       version:
-        description: "Export version tag"
+        description: "Export version tag (no v prefix, only 1.0.0)"
         value: ${{ jobs.tag-release.outputs.version }}
 
 jobs:
@@ -53,4 +53,4 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           environment: production
-          version: ${{ needs.tag-release.outputs.version }}
+          version: v${{ needs.tag-release.outputs.version }}


### PR DESCRIPTION
We tag the commit in format v1.0.0, in the meantime we build
docker with version just 1.0.0. We deploy heroku with v1.0.0.
And we create sentry release as 1.0.0.

We now should use v1.0.0 everywhere
