### PR TITLE
fix(sentry): Throttle specific errors (EWITAI canceled)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "strict": true,
     "noImplicitAny": false,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   }
 }


### PR DESCRIPTION
We can not do much about EWITAI canceled error, but it also floods Sentry and most of the time we are blind for other types of errors We now send only 10% of such specific error types.