### PR TITLE
fix(telegram): Remove messageId from params

### DIFF
--- a/src/telegram/actions/common.ts
+++ b/src/telegram/actions/common.ts
@@ -63,7 +63,6 @@ export abstract class GenericAction {
 
   public async sendMessage(
     chatId: number,
-    messageId: number,
     ids: TranslationKeyFull[],
     meta: MessageOptions,
     prefix: TelegramMessagePrefix,
@@ -87,9 +86,7 @@ export abstract class GenericAction {
       meta.options,
       forumThreadId,
     )
-      .then(() =>
-        this.sendMessage(chatId, messageId, ids, meta, prefix, forumThreadId),
-      )
+      .then(() => this.sendMessage(chatId, ids, meta, prefix, forumThreadId))
       .catch((err) => {
         logger.error(`${prefix.getPrefix()} Unable to send the message`, err);
         throw err;

--- a/src/telegram/actions/donate.ts
+++ b/src/telegram/actions/donate.ts
@@ -82,7 +82,6 @@ export class DonateAction extends GenericAction {
 
         return this.sendMessage(
           model.chatId,
-          model.id,
           [TranslationKeys.DonateCommandMessage],
           {
             lang,

--- a/src/telegram/actions/lang.ts
+++ b/src/telegram/actions/lang.ts
@@ -122,7 +122,6 @@ export class LangAction extends GenericAction {
 
         return this.sendMessage(
           chatId,
-          messageId,
           [TranslationKeys.UpdateLanguageError],
           { lang },
           prefix,
@@ -208,7 +207,6 @@ export class LangAction extends GenericAction {
 
         return this.sendMessage(
           model.chatId,
-          model.id,
           [TranslationKeys.ChangeLangTitle],
           {
             lang,

--- a/src/telegram/actions/start.ts
+++ b/src/telegram/actions/start.ts
@@ -39,7 +39,6 @@ export class StartAction extends GenericAction {
       .then((lang) =>
         this.sendMessage(
           model.chatId,
-          model.id,
           [
             TranslationKeys.WelcomeMessage,
             TranslationKeys.WelcomeMessageGroup,

--- a/src/telegram/actions/support.ts
+++ b/src/telegram/actions/support.ts
@@ -65,7 +65,6 @@ export class SupportAction extends GenericAction {
 
         return this.sendMessage(
           model.chatId,
-          model.id,
           [TranslationKeys.SupportCommand],
           {
             lang,

--- a/src/telegram/actions/voice-format.ts
+++ b/src/telegram/actions/voice-format.ts
@@ -55,7 +55,6 @@ export class VoiceFormatAction extends GenericAction {
       .then((lang) =>
         this.sendMessage(
           model.chatId,
-          model.id,
           [
             TranslationKeys.AudioNotSupportedMessage,
             [

--- a/src/telegram/actions/voice-length.ts
+++ b/src/telegram/actions/voice-length.ts
@@ -61,7 +61,6 @@ export class VoiceLengthAction extends GenericAction {
       .then((lang) =>
         this.sendMessage(
           model.chatId,
-          model.id,
           [
             [
               TranslationKeys.LongVoiceMessage,

--- a/src/telegram/actions/voice.ts
+++ b/src/telegram/actions/voice.ts
@@ -86,7 +86,6 @@ export class VoiceAction extends GenericAction {
 
           return this.sendMessage(
             model.chatId,
-            model.id,
             [TranslationKeys.RecognitionEmpty],
             {
               lang,
@@ -133,7 +132,6 @@ export class VoiceAction extends GenericAction {
 
         return this.sendMessage(
           model.chatId,
-          model.id,
           [TranslationKeys.RecognitionFailed],
           {
             lang,
@@ -176,7 +174,6 @@ export class VoiceAction extends GenericAction {
 
     return this.sendMessage(
       model.chatId,
-      model.id,
       [TranslationKeys.InProgress],
       {
         lang,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -207,7 +207,6 @@ export class TelegramBotModel {
       .then((lang) =>
         this.actions.core.sendMessage(
           model.chatId,
-          model.id,
           [TranslationKeys.NoContent],
           { lang },
           prefix,


### PR DESCRIPTION
The sendMessage method does not take any messageId because it sends new messages. We want to remove the redundant parameter