### PR TITLE
fix(telegram): Do not initialize api module inside the Reflector

### DIFF
--- a/src/telegram/api/groups/core.ts
+++ b/src/telegram/api/groups/core.ts
@@ -12,11 +12,10 @@ export class TelegramBaseApi {
 
   private readonly client: AxiosInstance;
   private readonly apiToken: string;
-  private readonly errorReflector?: ApiErrorReflector;
+  private errorReflector?: ApiErrorReflector;
 
-  constructor(apiToken: string, errorReflector?: ApiErrorReflector) {
+  constructor(apiToken: string) {
     this.apiToken = apiToken;
-    this.errorReflector = errorReflector;
 
     this.client = axios.create({
       method: "POST",
@@ -28,6 +27,10 @@ export class TelegramBaseApi {
       timeout: TelegramBaseApi.timeout,
       responseType: "json",
     });
+  }
+
+  public setErrorReflector(errorReflector: ApiErrorReflector): void {
+    this.errorReflector = errorReflector;
   }
 
   public async requestValidate<

--- a/src/telegram/api/tgapi.ts
+++ b/src/telegram/api/tgapi.ts
@@ -7,14 +7,20 @@ import { TelegramChatsApi } from "./groups/chats/chats-api.js";
 export const TELEGRAM_API_MAX_MESSAGE_SIZE = 4096;
 
 export class TelegramApi {
+  private readonly baseClient: TelegramBaseApi;
+
   public readonly chats: TelegramChatsApi;
   public readonly updates: TelegramUpdatesApi;
   public readonly payments: TelegramPaymentsApi;
 
-  constructor(apiToken: string, errorReflector?: ApiErrorReflector) {
-    const client = new TelegramBaseApi(apiToken, errorReflector);
-    this.chats = new TelegramChatsApi(client, apiToken);
-    this.updates = new TelegramUpdatesApi(client);
-    this.payments = new TelegramPaymentsApi(client);
+  constructor(apiToken: string) {
+    this.baseClient = new TelegramBaseApi(apiToken);
+    this.chats = new TelegramChatsApi(this.baseClient, apiToken);
+    this.updates = new TelegramUpdatesApi(this.baseClient);
+    this.payments = new TelegramPaymentsApi(this.baseClient);
+  }
+
+  public setErrorReflector(errorReflector: ApiErrorReflector): void {
+    this.baseClient.setErrorReflector(errorReflector);
   }
 }

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -36,8 +36,12 @@ export class TelegramBotModel {
     stat: ReturnType<typeof getDb>,
   ) {
     this.token = token;
-    const reflector = initTgReflector(this.token);
-    this.bot = new TelegramApi(this.token, reflector);
+
+    this.bot = new TelegramApi(this.token);
+    const reflector = initTgReflector({
+      leaveChat: (chatId) => this.bot.chats.leaveChat(chatId),
+    });
+    this.bot.setErrorReflector(reflector);
     this.actions = new BotActions(stat, this.bot);
     this.actions.voice.setConverters(converters);
   }


### PR DESCRIPTION
do not initialize the Telegram api module twice. because it is an implicit dependency for the Error Reflector. In fact. we better off to provide specific api into error reflector and then use in the api module.