### PR TITLE
fix(WitAi): Fix memory leak

### DIFF
--- a/src/recognition/witai/wit.ai.ts
+++ b/src/recognition/witai/wit.ai.ts
@@ -165,11 +165,14 @@ export class WithAiProvider extends VoiceConverter {
         return response.data;
       })
       .catch((err) => {
-        const witAiError = new WitAiError(err, err.message)
+        const attachedError = axios.isAxiosError(err) ? err.toJSON() : err;
+        delete attachedError?.config;
+
+        const witAiError = new WitAiError(attachedError, attachedError.message)
           .setUrl(url)
-          .setErrorCode(err?.response?.status)
-          .setResponse(err?.response?.data)
+          .setErrorCode(attachedError?.status)
           .setBufferLength(data);
+
         throw witAiError;
       })
       .then((response) => {


### PR DESCRIPTION
Axios error contains the whole api object with request, response and the config. The config included the body payload, in our case it can be a huge buffer object. apparently, in our implementation the NodeJS is having hard time to garbage collect it and hence We hold Megabytes of unused buffers. In this commit we serialize the axios error and then also delete the initial config, we already know the place the axios is called so it is easy to navigate the error anyways