### PR TITLE
fix(): Live if MTProto can not initialize (Closes #485)

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -124,6 +124,7 @@ export class Logger {
     // eslint-disable-next-line no-console
     console.warn(Logger.y(this.getFullPrefix()), msg, data ?? "");
     sendLogs("warn", this.getFullPrefix(false), msg, data);
+    trackApplicationErrors("Warning");
     if (shouldReport) {
       captureWarning(msg, data);
     }
@@ -137,6 +138,6 @@ export class Logger {
     console.error(Logger.r(this.getFullPrefix()), Logger.r(msg), data ?? "");
     sendLogs("error", this.getFullPrefix(false), msg, data);
     captureError(data);
-    trackApplicationErrors();
+    trackApplicationErrors("Error");
   }
 }

--- a/src/monitoring/newrelic.ts
+++ b/src/monitoring/newrelic.ts
@@ -31,6 +31,6 @@ export const trackRecognitionTime = (
   newrelic.recordMetric(metricName, durationMSec);
 };
 
-export const trackApplicationErrors = () => {
-  newrelic.incrementMetric(`ApplicationHealth/Error`);
+export const trackApplicationErrors = (type: "Error" | "Warning"): void => {
+  newrelic.incrementMetric(`ApplicationHealth/${type}`);
 };

--- a/src/telegram/actions/voice.ts
+++ b/src/telegram/actions/voice.ts
@@ -72,7 +72,7 @@ export class VoiceAction extends GenericAction {
     trackProcessFile("progress");
 
     return this.getFileLInk(model, prefix)
-      .then(([fileLink, fileId, isLocalFile]) => {
+      .then(([fileId, fileLink, isLocalFile]) => {
         if (!this.converters) {
           return Promise.reject(new Error("Voice converters are not set!"));
         }
@@ -172,7 +172,7 @@ export class VoiceAction extends GenericAction {
   private async getFileLInk(
     model: BotMessageModel,
     prefix: TelegramMessagePrefix,
-  ): Promise<[string, FileId, boolean]> {
+  ): Promise<[FileId, string, boolean]> {
     logger.info(`${prefix.getPrefix()} Fetching file link`);
 
     if (!model.voiceFileId) {
@@ -181,19 +181,17 @@ export class VoiceAction extends GenericAction {
       );
     }
 
-    // const fileUrl = await this.bot.chats.getFile(
-    //     model.voiceFileId,
-    //     model.chatId
-    // );
-    //
-    // return [fileUrl, model.voiceFileId, false]
-
-    const filePath = await this.bot.downloadFile(
+    const [fileLink, isLocalFile] = await this.bot.downloadFile(
       getFullFileName("original_file", true),
       model.voiceFileId,
+      model.chatId,
     );
 
-    return [filePath, model.voiceFileId, true];
+    if (!isLocalFile) {
+      logger.warn("Using the API download! Reload the application");
+    }
+
+    return [model.voiceFileId, fileLink, isLocalFile];
   }
 
   private sendInProgressMessage(

--- a/src/telegram/api/__mocks__/tgMTProtoApi.ts
+++ b/src/telegram/api/__mocks__/tgMTProtoApi.ts
@@ -12,6 +12,7 @@ export const setCurrentMockFileId = (id: FileId): void => {
 
 export const getMTProtoApi = (): TgProto => {
   return {
+    isInitialized: () => true,
     start: async (): Promise<void> => {
       return Promise.resolve();
     },

--- a/src/telegram/api/tgMTProtoApi.ts
+++ b/src/telegram/api/tgMTProtoApi.ts
@@ -3,6 +3,7 @@ import type { ChatId, FileId } from "./core.js";
 import { API_TIMEOUT_MS } from "../../const.js";
 
 export type TgProto = {
+  isInitialized: () => boolean;
   start: () => Promise<void>;
   stop: () => Promise<void>;
   downloadFile: (toFilename: string, fileId: FileId) => Promise<string>;
@@ -21,6 +22,9 @@ export const getMTProtoApi = (
   });
 
   return {
+    isInitialized: (): boolean => {
+      return isInitialized;
+    },
     start: async (): Promise<void> => {
       await client.start({
         botToken: apiToken,

--- a/src/telegram/api/tgapi.ts
+++ b/src/telegram/api/tgapi.ts
@@ -4,7 +4,7 @@ import { TelegramPaymentsApi } from "./groups/payments/payments-api.js";
 import { TelegramUpdatesApi } from "./groups/updates/updates-api.js";
 import { TelegramChatsApi } from "./groups/chats/chats-api.js";
 import { getMTProtoApi, type TgProto } from "./tgMTProtoApi.js";
-import type { FileId } from "./core.js";
+import type { ChatId, FileId } from "./core.js";
 
 export const TELEGRAM_API_MAX_MESSAGE_SIZE = 4096;
 
@@ -37,9 +37,15 @@ export class TelegramApi {
   public async downloadFile(
     toFilename: string,
     fileId: FileId,
-  ): Promise<string> {
-    await this.proto.downloadFile(toFilename, fileId);
-    return toFilename;
+    chatId: ChatId,
+  ): Promise<[string, boolean]> {
+    if (this.proto.isInitialized()) {
+      await this.proto.downloadFile(toFilename, fileId);
+      return [toFilename, true];
+    }
+
+    const fileUrl = await this.chats.getFile(fileId, chatId);
+    return [fileUrl, false];
   }
 
   public setErrorReflector(errorReflector: ApiErrorReflector): void {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -45,7 +45,14 @@ export class TelegramBotModel {
       converters,
       stat,
     );
-    await api.init();
+    try {
+      await api.init();
+    } catch (err) {
+      logger.error(
+        "MTProto client is unable to initialize. Falling back to API download",
+        err,
+      );
+    }
     return api;
   }
 


### PR DESCRIPTION
```
Failed to run the server RpcError (420 FLOOD_WAIT_%d): A wait of 3014 seconds is required
     at auth.importBotAuthorization
     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
     at async signInBot (file:///usr/src/app/node_modules/.pnpm/@mtcute+core@0.24.1/node_modules/@mtcute/core/highlevel/methods/auth/sign-in-bot.js:4:15)
     at async Object.start (file:///usr/src/app/dist/src/telegram/api/tgMTProtoApi.js:11:13)
     at async TelegramApi.init (file:///usr/src/app/dist/src/telegram/api/tgapi.js:22:9)
     at async TelegramBotModel.init (file:///usr/src/app/dist/src/telegram/bot.js:41:9)
     at async TelegramBotModel.factory (file:///usr/src/app/dist/src/telegram/bot.js:27:9)
     at async prepareInstance (file:///usr/src/app/dist/src/server/boot.js:41:17)
     at async Module.run (file:///usr/src/app/dist/src/scripts/cluster.js:25:9)
     at async file:///usr/src/app/dist/src/scripts/run.js:13:5 {
   code: 420,
   text: 'FLOOD_WAIT_%d',
   seconds: 3014
 }
```