### PR TITLE
fix(recognition): Free up the Blobs regardless

### DIFF
--- a/src/ffmpeg/index.ts
+++ b/src/ffmpeg/index.ts
@@ -98,8 +98,8 @@ export const getAudioBlob = async (
   fileLink: string,
   isLocalFile: boolean,
   shouldConvertToWav = true,
-): Promise<[Blob, string]> => {
+): Promise<{ fileBlob: Blob; filePath: string }> => {
   const filePath = await getAudioFilePath(fileLink, isLocalFile, shouldConvertToWav);
   const fileBlob = await openAsBlob(filePath);
-  return [fileBlob, filePath];
+  return { fileBlob, filePath };
 };

--- a/src/recognition/apiBase.ts
+++ b/src/recognition/apiBase.ts
@@ -43,7 +43,9 @@ export abstract class APIVoiceConverter<Res> extends VoiceConverter {
   ): Promise<string> {
     const name = `${logData.fileId}.ogg`;
     logger.info(`${logData.prefix} Starting process for ${Logger.y(name)}`);
-    const [fileBlob, filePath] = await getAudioBlob(fileLink, isLocalFile, !this.useRawFile);
+    const file = await getAudioBlob(fileLink, isLocalFile, !this.useRawFile);
+    let fileBlob: null | Blob = file.fileBlob;
+    let filePath: null | string = file.filePath;
     logger.info(`${logData.prefix} Start converting ${Logger.y(name)}`);
 
     try {
@@ -59,6 +61,10 @@ export abstract class APIVoiceConverter<Res> extends VoiceConverter {
       return result;
     } finally {
       await deleteFileIfExists(filePath);
+      // eslint-disable-next-line no-useless-assignment
+      fileBlob = null;
+      // eslint-disable-next-line no-useless-assignment
+      filePath = null;
     }
   }
 

--- a/src/recognition/apiSelfHost.ts
+++ b/src/recognition/apiSelfHost.ts
@@ -38,10 +38,11 @@ export class ApiSelfHost extends APIVoiceConverter<ApiResponse> {
     const duration = new TimeMeasure();
     const url = this.url;
 
+    let form: null | FormData = new FormData();
+
     try {
       const language = convertLanguageCodeToISO(lang);
 
-      const form = new FormData();
       form.append("language", language);
 
       const fileName =
@@ -97,6 +98,9 @@ export class ApiSelfHost extends APIVoiceConverter<ApiResponse> {
         unknownHasMessage(err) ? err.message : undefined,
       ).setUrl(url);
       throw requestError;
+    } finally {
+      // eslint-disable-next-line no-useless-assignment
+      form = null;
     }
   }
 

--- a/src/recognition/aws.ts
+++ b/src/recognition/aws.ts
@@ -101,7 +101,9 @@ export class AWSProvider extends VoiceConverter {
   }
 
   private async processFile(fileLink: string, name: string, isLocalFile: boolean): Promise<AWSJob> {
-    const [fileBlob, filePath] = await getAudioBlob(fileLink, isLocalFile);
+    const file = await getAudioBlob(fileLink, isLocalFile);
+    let fileBlob: null | Blob = file.fileBlob;
+    let filePath: null | string = file.filePath;
     try {
       const info1 = await this.uploadToS3(name, fileBlob);
       const info2 = await this.convertToText(name, info1.Location);
@@ -109,6 +111,10 @@ export class AWSProvider extends VoiceConverter {
       return text;
     } finally {
       await deleteFileIfExists(filePath);
+      // eslint-disable-next-line no-useless-assignment
+      fileBlob = null;
+      // eslint-disable-next-line no-useless-assignment
+      filePath = null;
     }
   }
 

--- a/src/recognition/elevenLabs.ts
+++ b/src/recognition/elevenLabs.ts
@@ -34,14 +34,19 @@ export class ElevenLabsProvider extends VoiceConverter {
   ): Promise<string> {
     const name = `${logData.fileId}.ogg`;
     logger.info(`${logData.prefix} Starting process for ${Logger.y(name)}`);
-    const [fileBlob, filePath] = await getAudioBlob(fileLink, isLocalFile);
-
+    const file = await getAudioBlob(fileLink, isLocalFile);
+    let fileBlob: null | Blob = file.fileBlob;
+    let filePath: null | string = file.filePath;
     logger.info(`${logData.prefix} Start converting ${Logger.y(name)}`);
     try {
       const text = await this.recognise(fileBlob, fileDuration, lang);
       return text;
     } finally {
       await deleteFileIfExists(filePath);
+      // eslint-disable-next-line no-useless-assignment
+      fileBlob = null;
+      // eslint-disable-next-line no-useless-assignment
+      filePath = null;
     }
   }
 

--- a/src/recognition/google.ts
+++ b/src/recognition/google.ts
@@ -43,7 +43,9 @@ export class GoogleProvider extends VoiceConverter {
     logger.info(`Starting process for ${Logger.y(name)}`);
     const duration = new TimeMeasure();
 
-    const [fileBlob, filePath] = await getAudioBlob(fileLink, isLocalFile);
+    const file = await getAudioBlob(fileLink, isLocalFile);
+    let fileBlob: null | Blob = file.fileBlob;
+    let filePath: null | string = file.filePath;
     logger.info(`Start converting ${Logger.y(name)}`);
 
     try {
@@ -69,6 +71,10 @@ export class GoogleProvider extends VoiceConverter {
       return text;
     } finally {
       await deleteFileIfExists(filePath);
+      // eslint-disable-next-line no-useless-assignment
+      fileBlob = null;
+      // eslint-disable-next-line no-useless-assignment
+      filePath = null;
     }
   }
 

--- a/src/recognition/witai/wit.ai.ts
+++ b/src/recognition/witai/wit.ai.ts
@@ -38,7 +38,9 @@ export class WithAiProvider extends VoiceConverter {
   ): Promise<string> {
     const name = `${logData.fileId}.ogg`;
     logger.info(`${logData.prefix} Starting process for ${Logger.y(name)}`);
-    const [fileBlob, filePath] = await getAudioBlob(fileLink, isLocalFile);
+    const file = await getAudioBlob(fileLink, isLocalFile);
+    let fileBlob: null | Blob = file.fileBlob;
+    let filePath: null | string = file.filePath;
     logger.info(`${logData.prefix} Start converting ${Logger.y(name)}`);
     const token = this.getApiToken(lang);
     if (!token) {
@@ -52,6 +54,10 @@ export class WithAiProvider extends VoiceConverter {
       return result;
     } finally {
       await deleteFileIfExists(filePath);
+      // eslint-disable-next-line no-useless-assignment
+      fileBlob = null;
+      // eslint-disable-next-line no-useless-assignment
+      filePath = null;
     }
   }
 


### PR DESCRIPTION
There is an idea that once we fail the recognition request, the file blob may not be fully consumed, hence NodeJS has no
clue if it need to free up the memory.
In this commit I am explicitly nullifying the variable to let Node know - it's time to clean up