### PR TITLE
fix(api): Do not transform error response

### DIFF
--- a/src/analytics/ga/index.ts
+++ b/src/analytics/ga/index.ts
@@ -46,7 +46,7 @@ export const collectEvents = async (chatId: ChatId, events: AnalyticsEventExt[])
       signal: AbortSignal.timeout(API_TIMEOUT_MS),
     });
 
-    const errResp = await getResponseErrorData(response, { raw: true });
+    const errResp = await getResponseErrorData(response);
 
     if (!response.ok) {
       throw new Error(`GA request failed: ${response.status} ${errResp}`);

--- a/src/server/api.spec.ts
+++ b/src/server/api.spec.ts
@@ -87,26 +87,7 @@ describe("requestHealthData", () => {
       const { url, code, response } = err as HealthError;
       expect(url).toEqual(`${TEST_URL}/health`);
       expect(code).toEqual(400);
-      expect(response).toEqual("TEST RESPONSE");
-    }
-  });
-
-  it("should get the API error and parse the json", async () => {
-    const testResponse = new Response(JSON.stringify({ foo: "bar" }), {
-      status: 400,
-      statusText: "ok",
-    });
-
-    vi.spyOn(global, "fetch").mockResolvedValue(testResponse);
-
-    try {
-      await requestHealthData(TEST_URL);
-      throw new Error("Should not resolve");
-    } catch (err) {
-      const { url, code, response } = err as HealthError;
-      expect(url).toEqual(`${TEST_URL}/health`);
-      expect(code).toEqual(400);
-      expect(response).toEqual({ foo: "bar" });
+      expect(response).toEqual('"TEST RESPONSE"');
     }
   });
 });

--- a/src/server/error.ts
+++ b/src/server/error.ts
@@ -8,15 +8,15 @@ const toJson = (text: string): unknown => {
 
 export const getResponseErrorData = async (
   response: Response,
-  opts?: { raw: boolean },
+  opts?: { toJson: boolean },
 ): Promise<unknown> => {
   try {
     const text = await response.text();
-    if (opts?.raw) {
-      return text;
+    if (opts?.toJson) {
+      return toJson(text);
     }
 
-    return toJson(text);
+    return text;
   } catch {
     return "no response";
   }


### PR DESCRIPTION
Read the error responses as text, do not try parsing it as JSON.