### PR TITLE
fix(recognition): Handle HTTP: 413 error during voice recognition

### DIFF
--- a/src/recognition/apiBase.ts
+++ b/src/recognition/apiBase.ts
@@ -74,28 +74,3 @@ export abstract class APIVoiceConverter<Res> extends VoiceConverter {
 
   protected abstract isRecognitionResponse(response: unknown): response is Res;
 }
-
-export class APIVoiceConverterError extends Error {
-  public code = 0;
-  public response?: unknown;
-  public url = "";
-
-  constructor(cause: unknown, message = "Request was unsuccessful") {
-    super(`EAPICONVERTER ${message}`, { cause });
-  }
-
-  public setResponseCode(code = 0): this {
-    this.code = code;
-    return this;
-  }
-
-  public setResponse(response?: unknown): this {
-    this.response = response;
-    return this;
-  }
-
-  public setUrl(url: string): this {
-    this.url = url;
-    return this;
-  }
-}

--- a/src/recognition/apiSelfHost.ts
+++ b/src/recognition/apiSelfHost.ts
@@ -1,5 +1,6 @@
 import type { LanguageCode } from "./types.js";
-import { APIVoiceConverter, APIVoiceConverterError } from "./apiBase.js";
+import { APIVoiceConverter } from "./apiBase.js";
+import { APIVoiceConverterError } from "./apiSelfHostError.js";
 import { convertLanguageCodeToISO } from "./common.js";
 import { TimeMeasure } from "../common/timer.js";
 import { API_TIMEOUT_MS } from "../const.js";
@@ -74,7 +75,7 @@ export class ApiSelfHost extends APIVoiceConverter<ApiResponse> {
         const errorMessage = "Wrong api response object";
         const requestError = new APIVoiceConverterError(new Error(errorMessage), errorMessage)
           .setUrl(url)
-          .setResponse(recognition)
+          .setResponse(JSON.stringify(recognition))
           .setResponseCode(response.status);
         throw requestError;
       }

--- a/src/recognition/apiSelfHostError.spec.ts
+++ b/src/recognition/apiSelfHostError.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  APIVoiceConverterError,
+  getReportedDurationSec,
+  isVoiceTooLongError,
+} from "./apiSelfHostError.js";
+
+describe("apiSelfHostError", () => {
+  describe("APIVoiceConverterError", () => {
+    it("should construct with default values", () => {
+      const cause = new Error("original");
+      const err = new APIVoiceConverterError(cause);
+
+      expect(err.cause).toBe(cause);
+      expect(err.message).toBe("EAPICONVERTER Request was unsuccessful");
+      expect(err.code).toBe(0);
+      expect(err.response).toBe(undefined);
+      expect(err.url).toBe("");
+    });
+
+    it("should construct with a custom message", () => {
+      const cause = new Error("original");
+      const msg = "ooops";
+      const err = new APIVoiceConverterError(cause, msg);
+
+      expect(err.cause).toBe(cause);
+      expect(err.message).toBe(`EAPICONVERTER ${msg}`);
+    });
+
+    it("should set the response code", () => {
+      const err = new APIVoiceConverterError(new Error("x")).setResponseCode(413);
+      expect(err.code).toBe(413);
+    });
+
+    it("should set the response body", () => {
+      const body = '{"foo":"bar"}';
+      const err = new APIVoiceConverterError(new Error("x")).setResponse(body);
+      expect(err.response).toBe(body);
+    });
+
+    it("should set the url", () => {
+      const url = "https://example.com";
+      const err = new APIVoiceConverterError(new Error("x")).setUrl(url);
+      expect(err.url).toBe(url);
+    });
+  });
+
+  describe("isVoiceTooLongError", () => {
+    it("should return true for an APIVoiceConverterError with code 413", () => {
+      const err = new APIVoiceConverterError(new Error("x")).setResponseCode(413);
+      expect(isVoiceTooLongError(err)).toBe(true);
+    });
+
+    it.each([0, 400, 404, 500])(
+      "should return false for an APIVoiceConverterError with code %s",
+      (code) => {
+        const err = new APIVoiceConverterError(new Error("x")).setResponseCode(code);
+        expect(isVoiceTooLongError(err)).toBe(false);
+      },
+    );
+
+    it("should return false for a non-APIVoiceConverterError error with a 413 code property", () => {
+      const err = Object.assign(new Error("x"), { code: 413 });
+      expect(isVoiceTooLongError(err)).toBe(false);
+    });
+  });
+
+  describe("getReportedDurationSec", () => {
+    it("should return the duration when the response contains duration_seconds", () => {
+      const expected = 45.2;
+      const err = new APIVoiceConverterError(new Error("x")).setResponseCode(413).setResponse(
+        JSON.stringify({
+          error: "Audio too long",
+          duration_seconds: expected,
+          max_duration_seconds: 30,
+        }),
+      );
+
+      expect(getReportedDurationSec(err)).toBe(expected);
+    });
+
+    it("should return 0 when the response is not set", () => {
+      const err = new APIVoiceConverterError(new Error("x"));
+      expect(getReportedDurationSec(err)).toBe(0);
+    });
+
+    it("should return 0 when the response is an empty string", () => {
+      const err = new APIVoiceConverterError(new Error("x")).setResponse("");
+      expect(getReportedDurationSec(err)).toBe(0);
+    });
+
+    it("should return 0 when the response is not valid JSON", () => {
+      const err = new APIVoiceConverterError(new Error("x")).setResponse("not json");
+      expect(getReportedDurationSec(err)).toBe(0);
+    });
+
+    it("should return 0 when duration_seconds is missing", () => {
+      const err = new APIVoiceConverterError(new Error("x")).setResponse(
+        JSON.stringify({ error: "Audio too long" }),
+      );
+      expect(getReportedDurationSec(err)).toBe(0);
+    });
+
+    it.each([
+      ["string", '{"duration_seconds":"45.2"}'],
+      ["null", '{"duration_seconds":null}'],
+      ["boolean", '{"duration_seconds":true}'],
+      ["array", '{"duration_seconds":[45.2]}'],
+      ["object", '{"duration_seconds":{"value":45.2}}'],
+    ])("should return 0 when duration_seconds is a %s", (_, body) => {
+      const err = new APIVoiceConverterError(new Error("x")).setResponse(body);
+      expect(getReportedDurationSec(err)).toBe(0);
+    });
+
+    it("should return 0 when the parsed JSON is not an object", () => {
+      const err = new APIVoiceConverterError(new Error("x")).setResponse("42");
+      expect(getReportedDurationSec(err)).toBe(0);
+    });
+  });
+});

--- a/src/recognition/apiSelfHostError.ts
+++ b/src/recognition/apiSelfHostError.ts
@@ -1,0 +1,40 @@
+export class APIVoiceConverterError extends Error {
+  public code = 0;
+  public response?: string;
+  public url = "";
+
+  constructor(cause: unknown, message = "Request was unsuccessful") {
+    super(`EAPICONVERTER ${message}`, { cause });
+  }
+
+  public setResponseCode(code = 0): this {
+    this.code = code;
+    return this;
+  }
+
+  public setResponse(response?: string): this {
+    this.response = response;
+    return this;
+  }
+
+  public setUrl(url: string): this {
+    this.url = url;
+    return this;
+  }
+}
+
+export const isVoiceTooLongError = (err: unknown): err is APIVoiceConverterError => {
+  return err instanceof APIVoiceConverterError && err.code === 413;
+};
+
+export const getReportedDurationSec = (err: APIVoiceConverterError): number => {
+  if (!err.response) {
+    return 0;
+  }
+  try {
+    const parsed = JSON.parse(err.response) as { duration_seconds?: number };
+    return typeof parsed.duration_seconds === "number" ? parsed.duration_seconds : 0;
+  } catch {
+    return 0;
+  }
+};

--- a/src/telegram/actions/common.ts
+++ b/src/telegram/actions/common.ts
@@ -14,7 +14,7 @@ import type { TgMessageOptions } from "../api/groups/chats/chats-types.js";
 
 const logger = new Logger("telegram-bot");
 
-export abstract class GenericAction {
+export class CoreAction {
   protected readonly text = getTranslator();
 
   protected readonly stat: ReturnType<typeof getDb>;
@@ -24,14 +24,6 @@ export abstract class GenericAction {
     this.stat = stat;
     this.bot = bot;
   }
-
-  public abstract runAction(mdl: BotMessageModel, prefix: TelegramMessagePrefix): Promise<void>;
-
-  public abstract runCondition(
-    msg: TgMessage,
-    mdl: BotMessageModel,
-    prefix: TelegramMessagePrefix,
-  ): Promise<boolean>;
 
   public async getChatLanguage(
     model: BotMessageModel,
@@ -124,12 +116,12 @@ export abstract class GenericAction {
   }
 }
 
-export class CoreAction extends GenericAction {
-  public async runAction(): Promise<void> {
-    return;
-  }
+export abstract class GenericAction extends CoreAction {
+  public abstract runAction(mdl: BotMessageModel, prefix: TelegramMessagePrefix): Promise<void>;
 
-  public async runCondition(): Promise<boolean> {
-    return false;
-  }
+  public abstract runCondition(
+    msg: TgMessage,
+    mdl: BotMessageModel,
+    prefix: TelegramMessagePrefix,
+  ): Promise<boolean>;
 }

--- a/src/telegram/actions/voice-length.ts
+++ b/src/telegram/actions/voice-length.ts
@@ -1,27 +1,27 @@
-import { GenericAction } from "./common.js";
+import type { GenericAction } from "./common.js";
 import { isVoiceMessage } from "../helpers.js";
 import { Logger } from "../../logger/index.js";
-import { TranslationKeys } from "../../text/types.js";
-import { collectAnalytics } from "../../analytics/index.js";
 import { VoiceContentReason } from "../types.js";
 import type { TelegramMessagePrefix } from "../models/messagePrefix.js";
 import type { BotMessageModel } from "../models/botMessage.js";
 import type { TgMessage } from "../api/types.js";
-import { getMaxDuration } from "../../text/utils.js";
-import type { LanguageCode } from "../../recognition/types.js";
 import { durationLimitSec } from "../../const.js";
+import { VoiceBaseAction } from "./voice/voice-base.js";
 
 const logger = new Logger("telegram-bot");
 
-export class VoiceLengthAction extends GenericAction {
-  private static readonly maxVoiceDuration = getMaxDuration();
-
+export class VoiceLengthAction extends VoiceBaseAction implements GenericAction {
   private static isVoiceMessageLong(model: BotMessageModel): boolean {
     return model.voiceDuration >= durationLimitSec;
   }
 
   public runAction(mdl: BotMessageModel, prefix: TelegramMessagePrefix): Promise<void> {
     mdl.analytics.addPageVisit();
+    logger.warn("Message is too long", {
+      durationSec: mdl.voiceDuration,
+      ...prefix,
+    });
+    mdl.analytics.addTime("voice-length", mdl.voiceDuration * 1_000);
     return this.sendVoiceIsTooLongMessage(mdl, prefix);
   }
 
@@ -29,78 +29,5 @@ export class VoiceLengthAction extends GenericAction {
     const type = isVoiceMessage(msg);
     const isVoice = type.type === VoiceContentReason.Ok;
     return isVoice && VoiceLengthAction.isVoiceMessageLong(mdl);
-  }
-
-  private async sendVoiceIsTooLongMessage(
-    model: BotMessageModel,
-    prefix: TelegramMessagePrefix,
-  ): Promise<void> {
-    logger.warn("Message is too long", {
-      durationSec: model.voiceDuration,
-      ...prefix,
-    });
-
-    model.analytics.addTime("voice-length", model.voiceDuration * 1_000);
-
-    if (model.isGroup) {
-      return collectAnalytics(
-        model.analytics.setCommand("/voice", "Voice message is too long", "Group"),
-      );
-    }
-
-    logger.info(`${prefix.getPrefix()} Sending voice is too long`);
-    return this.getChatLanguage(model, prefix)
-      .then((lang) =>
-        this.sendMessage(
-          model.chatId,
-          [
-            [
-              TranslationKeys.LongVoiceMessage,
-              {
-                duration: this.getDurationString(lang),
-              },
-            ],
-          ],
-          {
-            lang,
-          },
-          prefix,
-          model.forumThreadId,
-        ),
-      )
-      .then(() => logger.info(`${prefix.getPrefix()} Voice is too long message sent`))
-      .catch((err) => {
-        const errorMessage = "Unable to send voice is too long";
-        logger.error(`${prefix.getPrefix()} ${errorMessage}`, err);
-        model.analytics.addError(errorMessage);
-      })
-      .then(() =>
-        collectAnalytics(
-          model.analytics.setCommand("/voice", "Voice message is too long", "Private"),
-        ),
-      );
-  }
-
-  private getDurationString(lang: LanguageCode): string {
-    const [min, sec] = VoiceLengthAction.maxVoiceDuration;
-    const parts: string[] = [];
-    if (min > 0) {
-      parts.push(
-        this.text.t(TranslationKeys.FormattedTimeMinutes, lang, {
-          minutes: min,
-        }),
-      );
-    }
-
-    if (sec > 0) {
-      parts.push(
-        this.text.t(TranslationKeys.FormattedTimeSeconds, lang, {
-          seconds: sec,
-        }),
-      );
-    }
-
-    const duration = parts.filter(Boolean).join(" ");
-    return duration;
   }
 }

--- a/src/telegram/actions/voice.ts
+++ b/src/telegram/actions/voice.ts
@@ -1,4 +1,4 @@
-import { GenericAction } from "./common.js";
+import type { GenericAction } from "./common.js";
 import { isVoiceMessage } from "../helpers.js";
 import { Logger } from "../../logger/index.js";
 import { TranslationKeys } from "../../text/types.js";
@@ -24,10 +24,12 @@ import {
 } from "../../monitoring/newrelic.js";
 import { getConverterType } from "../../subscription/utils.js";
 import { addAttachment, clearAttachments } from "../../monitoring/sentry/index.js";
+import { getReportedDurationSec, isVoiceTooLongError } from "../../recognition/apiSelfHostError.js";
+import { VoiceBaseAction } from "./voice/voice-base.js";
 
 const logger = new Logger("telegram-bot");
 
-export class VoiceAction extends GenericAction {
+export class VoiceAction extends VoiceBaseAction implements GenericAction {
   private converters?: VoiceConverters;
 
   public runAction(mdl: BotMessageModel, prefix: TelegramMessagePrefix): Promise<void> {
@@ -165,6 +167,18 @@ export class VoiceAction extends GenericAction {
         return this.updateUsageCount(model, prefix);
       })
       .catch((err) => {
+        if (isVoiceTooLongError(err)) {
+          const actualVoiceDuration = getReportedDurationSec(err);
+          logger.warn(`${prefix.getPrefix()} Message is too long (api)`, {
+            durationSec: actualVoiceDuration,
+            ...prefix,
+          });
+          if (actualVoiceDuration) {
+            model.analytics.addTime("voice-length", actualVoiceDuration * 1_000);
+          }
+          return this.sendVoiceIsTooLongMessage(model, prefix);
+        }
+
         const isBlocked = isBlockedByUser(err);
         const errorMessage = "Unable to recognize the file";
         const duration = Logger.y(`${model.voiceDuration}sec`);

--- a/src/telegram/actions/voice/voice-base.ts
+++ b/src/telegram/actions/voice/voice-base.ts
@@ -1,0 +1,80 @@
+import { CoreAction } from "../common.js";
+import { Logger } from "../../../logger/index.js";
+import { TranslationKeys } from "../../../text/types.js";
+import { collectAnalytics } from "../../../analytics/index.js";
+import type { TelegramMessagePrefix } from "../../models/messagePrefix.js";
+import type { BotMessageModel } from "../../models/botMessage.js";
+import { getMaxDuration } from "../../../text/utils.js";
+import type { LanguageCode } from "../../../recognition/types.js";
+
+const logger = new Logger("telegram-bot");
+
+export abstract class VoiceBaseAction extends CoreAction {
+  protected static readonly maxVoiceDuration = getMaxDuration();
+
+  protected async sendVoiceIsTooLongMessage(
+    model: BotMessageModel,
+    prefix: TelegramMessagePrefix,
+  ): Promise<void> {
+    if (model.isGroup) {
+      return collectAnalytics(
+        model.analytics.setCommand("/voice", "Voice message is too long", "Group"),
+      );
+    }
+
+    logger.info(`${prefix.getPrefix()} Sending voice is too long`);
+    return this.getChatLanguage(model, prefix)
+      .then((lang) =>
+        this.sendMessage(
+          model.chatId,
+          [
+            [
+              TranslationKeys.LongVoiceMessage,
+              {
+                duration: this.getDurationString(lang),
+              },
+            ],
+          ],
+          {
+            lang,
+          },
+          prefix,
+          model.forumThreadId,
+        ),
+      )
+      .then(() => logger.info(`${prefix.getPrefix()} Voice is too long message sent`))
+      .catch((err) => {
+        const errorMessage = "Unable to send voice is too long";
+        logger.error(`${prefix.getPrefix()} ${errorMessage}`, err);
+        model.analytics.addError(errorMessage);
+      })
+      .then(() =>
+        collectAnalytics(
+          model.analytics.setCommand("/voice", "Voice message is too long", "Private"),
+        ),
+      );
+  }
+
+  private getDurationString(lang: LanguageCode): string {
+    const [min, sec] = VoiceBaseAction.maxVoiceDuration;
+    const parts: string[] = [];
+    if (min > 0) {
+      parts.push(
+        this.text.t(TranslationKeys.FormattedTimeMinutes, lang, {
+          minutes: min,
+        }),
+      );
+    }
+
+    if (sec > 0) {
+      parts.push(
+        this.text.t(TranslationKeys.FormattedTimeSeconds, lang, {
+          seconds: sec,
+        }),
+      );
+    }
+
+    const duration = parts.filter(Boolean).join(" ");
+    return duration;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
     },
     globalSetup: "./vitest.setup.ts",
     environment: "node",
+    env: {
+      NEW_RELIC_ENABLED: "false",
+    },
     include: [],
     exclude: [...defaultExclude],
     projects: [


### PR DESCRIPTION
- Extracted `sendVoiceIsTooLongMessage` and `getDurationString` from `VoiceLengthAction` into a new `VoiceBaseAction` class for reuse.
- Updated `VoiceAction` to extend `VoiceBaseAction` and handle `isVoiceTooLongError` (HTTP 413) caught during transcription.
- Ensure users receive the standard "Voice message is too long" feedback if the API rejects the payload due to duration limits, even if the initial duration metadata was incorrect.
- Disabled New Relic in `vitest.config.ts` to fix bootstrap errors during unit tests.