### PR TITLE
fix(sentry): Get rid of Newrelic breadcrumbs

### DIFF
--- a/src/monitoring/sentry/sentry-base.ts
+++ b/src/monitoring/sentry/sentry-base.ts
@@ -102,9 +102,12 @@ export abstract class SentryBase {
     });
   }
 
-  protected beforeSentrySend = <E extends { tags?: Record<string, unknown> }>(
+  protected beforeSentrySend = <
+    E extends { tags?: Record<string, unknown> },
+    H extends { originalException?: unknown },
+  >(
     event: E,
-    hint: { originalException?: unknown },
+    hint: H,
   ): E | null => {
     const error = hint.originalException;
 
@@ -132,4 +135,16 @@ export abstract class SentryBase {
 
     return event;
   };
+
+  protected beforeBreadcrumb<B extends { category?: string; data?: Record<string, unknown> }>(
+    breadcrumb: B,
+  ): B | null {
+    if (["fetch", "xhr", "http"].includes(breadcrumb.category || "")) {
+      const url = breadcrumb.data?.url;
+      if (typeof url === "string" && url.startsWith("https://collector.eu01.nr-data.net/")) {
+        return null;
+      }
+    }
+    return breadcrumb;
+  }
 }

--- a/src/monitoring/sentry/sentry-node.ts
+++ b/src/monitoring/sentry/sentry-node.ts
@@ -34,6 +34,7 @@ export class SentryNodeClient extends SentryBase {
       profilesSampleRate: isDevelopment() ? 1.0 : 0.2,
       sampleRate: isDevelopment() ? 1.0 : 0.5,
       beforeSend: (event, hint) => this.beforeSentrySend(event, hint),
+      beforeBreadcrumb: (breadcrumb) => this.beforeBreadcrumb(breadcrumb),
     });
 
     this.setFastifyRequestPlugin(app);


### PR DESCRIPTION
Clean up the breadcrumb view by dropping newrelic items. Also for security, since it prints the license key