### PR TITLE
fix(sentry): Attach userId and chatId to Sentry events

### DIFF
--- a/src/monitoring/newrelic.ts
+++ b/src/monitoring/newrelic.ts
@@ -1,7 +1,9 @@
 import newrelic from "newrelic";
+import type { FastifyInstance } from "fastify";
 import type { ChatType, VoiceType } from "../telegram/types.js";
 import type { VoiceConverterProvider } from "../recognition/types.js";
 import type { Currency } from "../telegram/api/groups/payments/payments-types.js";
+import { setFastifyPreHandler } from "../server/hook.js";
 
 const formatMetric = (metric: string): string => {
   // Snake_case to PascalCase
@@ -107,4 +109,19 @@ export const trackUnknownRoute = (route: string): void => {
 
 export const trackFileDownload = (type: "api" | "mtproto"): void => {
   newrelic.incrementMetric(`FileDownloadType/${formatMetric(type)}`);
+};
+
+export const initNewRelicRequestContext = (app: FastifyInstance): void => {
+  setFastifyPreHandler(app, (meta, done) => {
+    if (meta.userId) {
+      newrelic.setUserID(String(meta.userId));
+      newrelic.addCustomAttributes({
+        "tg.chatId": meta.chatId || "n/a",
+        "tg.userId": meta.userId || "n/a",
+        "tg.userLanguage": meta.lang || "n/a",
+      });
+    }
+
+    done();
+  });
 };

--- a/src/monitoring/sentry/sentry-base.ts
+++ b/src/monitoring/sentry/sentry-base.ts
@@ -3,16 +3,10 @@ import { appVersion, nodeEnvironment, sentryDsn } from "../../env.js";
 import { fetchPropFromUnknown } from "../../common/unknown.js";
 import { isDevelopment } from "../../common/environment.js";
 import type { VoidFunction } from "../../common/types.js";
+import { type HookMetadata, setFastifyPreHandler } from "../../server/hook.js";
 
 // Do not include the traces from Newrelic and Amplitude to keep the tracing clean
 const OMITTED_BREADCRUMBS = ["https://collector.eu01.nr-data.net/", "https://api2.amplitude.com/"];
-
-export type SentryMetadata = {
-  url?: string;
-  method?: string;
-  userId?: unknown;
-  chatId?: unknown;
-};
 
 export abstract class SentryBase {
   protected readonly appVersion = appVersion;
@@ -35,7 +29,7 @@ export abstract class SentryBase {
   public abstract clearAttachments(): void;
 
   protected abstract setMetadataAndTags(
-    meta: SentryMetadata,
+    meta: HookMetadata,
     tags: Record<string, string>,
     doneFn: VoidFunction,
   ): void;
@@ -64,41 +58,13 @@ export abstract class SentryBase {
   }
 
   protected setFastifyRequestPlugin(app: FastifyInstance): void {
-    app.addHook("preHandler", (request, _reply, done) => {
-      const { routeOptions, body } = request;
-      /**
-       * @see https://github.com/getsentry/sentry-javascript/pull/9138/files
-       */
-      const requestMessage = fetchPropFromUnknown(body, "message", {});
-      const requestUserLanguage = fetchPropFromUnknown<string>(
-        fetchPropFromUnknown(requestMessage, "from", {}),
-        "language_code",
-        "n/a",
-      );
-      const requestUserId = fetchPropFromUnknown<string>(
-        fetchPropFromUnknown(requestMessage, "from", {}),
-        "id",
-        "",
-      );
-      const requestChatId = fetchPropFromUnknown<string>(
-        fetchPropFromUnknown(requestMessage, "chat", {}),
-        "id",
-        "",
-      );
-
+    setFastifyPreHandler(app, (meta, done) => {
       this.setMetadataAndTags(
+        meta,
         {
-          url: routeOptions.url,
-          method: Array.isArray(routeOptions.method)
-            ? routeOptions.method.at(0)
-            : routeOptions.method,
-          userId: requestUserId,
-          chatId: requestChatId,
-        },
-        {
-          "tg.chatId": requestChatId || "n/a",
-          "tg.userId": requestUserId || "n/a",
-          "tg.userLanguage": requestUserLanguage,
+          "tg.chatId": meta.chatId || "n/a",
+          "tg.userId": meta.userId || "n/a",
+          "tg.userLanguage": meta.lang || "n/a",
         },
         done,
       );

--- a/src/monitoring/sentry/sentry-base.ts
+++ b/src/monitoring/sentry/sentry-base.ts
@@ -70,20 +70,20 @@ export abstract class SentryBase {
        * @see https://github.com/getsentry/sentry-javascript/pull/9138/files
        */
       const requestMessage = fetchPropFromUnknown(body, "message", {});
-      const requestUserId = fetchPropFromUnknown<string>(
-        fetchPropFromUnknown(requestMessage, "from", {}),
-        "id",
-        "n/a",
-      );
       const requestUserLanguage = fetchPropFromUnknown<string>(
         fetchPropFromUnknown(requestMessage, "from", {}),
         "language_code",
         "n/a",
       );
+      const requestUserId = fetchPropFromUnknown<string>(
+        fetchPropFromUnknown(requestMessage, "from", {}),
+        "id",
+        "",
+      );
       const requestChatId = fetchPropFromUnknown<string>(
         fetchPropFromUnknown(requestMessage, "chat", {}),
         "id",
-        "n/a",
+        "",
       );
 
       this.setMetadataAndTags(
@@ -96,8 +96,8 @@ export abstract class SentryBase {
           chatId: requestChatId,
         },
         {
-          "tg.chatId": requestChatId,
-          "tg.userId": requestUserId,
+          "tg.chatId": requestChatId || "n/a",
+          "tg.userId": requestUserId || "n/a",
           "tg.userLanguage": requestUserLanguage,
         },
         done,

--- a/src/monitoring/sentry/sentry-node.ts
+++ b/src/monitoring/sentry/sentry-node.ts
@@ -76,8 +76,15 @@ export class SentryNodeClient extends SentryBase {
     tags: Record<string, string>,
     doneFn: VoidFunction,
   ): void {
+    const user = meta.userId
+      ? {
+          id: meta.userId,
+          userId: meta.userId,
+          chatId: meta.chatId,
+        }
+      : null;
     withIsolationScope(() => {
-      getCurrentScope().setSDKProcessingMetadata(meta).setTags(tags);
+      getCurrentScope().setSDKProcessingMetadata(meta).setTags(tags).setUser(user);
       doneFn();
     });
   }

--- a/src/monitoring/sentry/sentry-node.ts
+++ b/src/monitoring/sentry/sentry-node.ts
@@ -8,9 +8,10 @@ import {
 } from "@sentry/node";
 import { nodeProfilingIntegration } from "@sentry/profiling-node";
 import type { FastifyInstance } from "fastify";
-import { SentryBase, type SentryMetadata } from "./sentry-base.js";
+import { SentryBase } from "./sentry-base.js";
 import { isDevelopment } from "../../common/environment.js";
 import type { VoidFunction } from "../../common/types.js";
+import type { HookMetadata } from "../../server/hook.js";
 
 export class SentryNodeClient extends SentryBase {
   public init(app: FastifyInstance): void {
@@ -72,7 +73,7 @@ export class SentryNodeClient extends SentryBase {
   }
 
   public setMetadataAndTags(
-    meta: SentryMetadata,
+    meta: HookMetadata,
     tags: Record<string, string>,
     doneFn: VoidFunction,
   ): void {

--- a/src/server/bot-server.ts
+++ b/src/server/bot-server.ts
@@ -13,7 +13,7 @@ import type { VoidPromise } from "../common/types.js";
 import type { HttpsOptions } from "../../certs/index.js";
 import type { TelegramBotModel } from "../telegram/bot.js";
 import { generateMemorySnapshotAsBuffer } from "../profiling/memory.js";
-import { trackUnknownRoute } from "../monitoring/newrelic.js";
+import { initNewRelicRequestContext, trackUnknownRoute } from "../monitoring/newrelic.js";
 
 const logger = new Logger("server");
 
@@ -28,6 +28,7 @@ export class BotServer extends BotServerBase<FastifyInstance> implements BotServ
     super("Fastify", port, version, webhookDoNotWait, httpsOptions, enableSnapshotCapture);
 
     initSentry(this.app);
+    initNewRelicRequestContext(this.app);
 
     this.app.get<{ Reply: string }>("/favicon.ico", async (_req, reply) => {
       return reply.status(204).type("image/vnd.microsoft.icon").send("");

--- a/src/server/hook.ts
+++ b/src/server/hook.ts
@@ -1,0 +1,52 @@
+import type { FastifyInstance } from "fastify";
+import type { VoidFunction } from "../common/types.js";
+import { fetchPropFromUnknown } from "../common/unknown.js";
+
+export type HookMetadata = {
+  url?: string;
+  method?: string;
+  userId?: string;
+  chatId?: string;
+  lang?: string;
+};
+
+export const setFastifyPreHandler = (
+  app: FastifyInstance,
+  callback: (meta: HookMetadata, doneFn: VoidFunction) => void,
+): void => {
+  app.addHook("preHandler", (request, _reply, done) => {
+    const { routeOptions, body } = request;
+    /**
+     * @see https://github.com/getsentry/sentry-javascript/pull/9138/files
+     */
+    const requestMessage = fetchPropFromUnknown(body, "message", {});
+    const requestUserLanguage = fetchPropFromUnknown<string>(
+      fetchPropFromUnknown(requestMessage, "from", {}),
+      "language_code",
+      "",
+    );
+    const requestUserId = fetchPropFromUnknown<string>(
+      fetchPropFromUnknown(requestMessage, "from", {}),
+      "id",
+      "",
+    );
+    const requestChatId = fetchPropFromUnknown<string>(
+      fetchPropFromUnknown(requestMessage, "chat", {}),
+      "id",
+      "",
+    );
+
+    callback(
+      {
+        url: routeOptions.url,
+        method: Array.isArray(routeOptions.method)
+          ? routeOptions.method.at(0)
+          : routeOptions.method,
+        userId: requestUserId,
+        chatId: requestChatId,
+        lang: requestUserLanguage,
+      },
+      done,
+    );
+  });
+};


### PR DESCRIPTION
- fix(sentry): Attach userId and chatId to Sentry events

Sentry alerts were missing user context because the request data was
only set via setSDKProcessingMetadata, which is SDK-internal and does
not surface in the alert UI. Use setUser so userId and chatId appear
on every event tied to a Telegram message.

- fix(newrelic): Attach userId and chatId to error inbox events

NewRelic Errors Inbox showed an empty Users column because nothing
called setUserID per request. Add a Fastify preHandler that sets
enduser.id and tg.* custom attributes from the Telegram webhook body,
and unify the body parsing with Sentry behind a shared hook helper.

