### PR TITLE
fix(error): Send raw error data to sentry

### DIFF
--- a/src/telegram/api/groups/core.ts
+++ b/src/telegram/api/groups/core.ts
@@ -4,6 +4,7 @@ import { TgError } from "../tgerror.js";
 import type { ChatId } from "../core.js";
 import { API_TIMEOUT_MS } from "../../../const.js";
 import { unknownHasMessage } from "../../../common/unknown.js";
+import { getResponseErrorData } from "../../../server/error.js";
 
 export class TelegramBaseApi {
   public static readonly url = "https://api.telegram.org";
@@ -36,18 +37,6 @@ export class TelegramBaseApi {
     return schema.parse(result);
   }
 
-  private async parseErrorResponse(response: Response): Promise<TgCore<void>> {
-    try {
-      const answer = (await response.json()) as TgCore<void>;
-      return answer;
-    } catch {
-      return {
-        ok: false,
-        result: undefined,
-      };
-    }
-  }
-
   private async request<Response, Data>(
     methodName: string,
     data?: Data,
@@ -68,7 +57,7 @@ export class TelegramBaseApi {
       });
 
       if (!response.ok) {
-        const answer = await this.parseErrorResponse(response);
+        const answer = await getResponseErrorData(response);
 
         const tgError = new TgError(new Error(response.statusText), response.statusText)
           .setUrl(url, this.apiToken)

--- a/src/telegram/api/tgapi.spec.ts
+++ b/src/telegram/api/tgapi.spec.ts
@@ -624,7 +624,7 @@ describe("[telegram api client]", () => {
           expect(err.message).toBe(`ETELEGRAM ${testErrorDescription}`);
           expect(err.code).toBe(testErrorCode);
           expect(err.url).toBe(`/bot${SANITIZE_CHARACTER}/setWebHook`);
-          expect(err.response).toBe(undefined);
+          expect(err.response).toBe("{}");
           expect(err.migrateToChatId).toBe(0);
           expect(err.retryAfter).toBe(0);
         });
@@ -677,7 +677,7 @@ describe("[telegram api client]", () => {
           expect(err.message).toBe(`ETELEGRAM ${testErrorDescription}`);
           expect(err.code).toBe(testErrorCode);
           expect(err.url).toBe(`/bot${SANITIZE_CHARACTER}/setMyCommands`);
-          expect(err.response).toBe(undefined);
+          expect(err.response).toBe("{}");
           expect(err.migrateToChatId).toBe(0);
           expect(err.retryAfter).toBe(testRetryAfter);
         });
@@ -702,7 +702,7 @@ describe("[telegram api client]", () => {
           expect(err.message).toBe("ETELEGRAM Telegram request was unsuccessful");
           expect(err.code).toBe(testErrorCode);
           expect(err.url).toBe(`/bot${SANITIZE_CHARACTER}/getWebhookInfo`);
-          expect(err.response).toBe(undefined);
+          expect(err.response).toBe("{}");
           expect(err.migrateToChatId).toBe(0);
           expect(err.retryAfter).toBe(0);
         });
@@ -747,7 +747,7 @@ describe("[telegram api client]", () => {
           expect(err.message).toBe(`ETELEGRAM ${testErrorDescription}`);
           expect(err.code).toBe(testErrorCode);
           expect(err.url).toBe(`/bot${SANITIZE_CHARACTER}/getFile`);
-          expect(err.response).toBe(undefined);
+          expect(err.response).toBe("{}");
           expect(err.migrateToChatId).toBe(testMigrateToChat);
           expect(err.retryAfter).toBe(testRetryAfter);
           expect(err.chatId).toBe(testChatId);
@@ -799,7 +799,7 @@ describe("[telegram api client]", () => {
           expect(err.message).toBe(`ETELEGRAM ${testErrMsg}`);
           expect(err.code).toBe(0);
           expect(err.url).toBe(`/bot${SANITIZE_CHARACTER}/editMessageText`);
-          expect(err.response).toBe(undefined);
+          expect(err.response).toBe("{}");
           expect(err.migrateToChatId).toBe(0);
           expect(err.retryAfter).toBe(0);
         });
@@ -826,7 +826,7 @@ describe("[telegram api client]", () => {
           expect(err.message).toBe(`ETELEGRAM ${testErrMsg}`);
           expect(err.code).toBe(errCode);
           expect(err.url).toBe(`/bot${SANITIZE_CHARACTER}/sendMessage`);
-          expect(err.response).toStrictEqual(errData);
+          expect(err.response).toStrictEqual(JSON.stringify(errData));
           expect(err.migrateToChatId).toBe(0);
           expect(err.retryAfter).toBe(0);
         });

--- a/src/telegram/api/tgerror.spec.ts
+++ b/src/telegram/api/tgerror.spec.ts
@@ -20,7 +20,7 @@ describe("tgerror", () => {
       expect(err.message).toBe(`ETELEGRAM ${msg}`);
       expect(err.code).toBe(0);
       expect(err.chatId).toBe(undefined);
-      expect(err.response).toBe(undefined);
+      expect(err.response).toBe("{}");
       expect(err.migrateToChatId).toBe(0);
       expect(err.retryAfter).toBe(0);
       expect(err.url).toBe("");
@@ -35,7 +35,7 @@ describe("tgerror", () => {
       expect(err.message).toBe(`ETELEGRAM ${msg}`);
       expect(err.code).toBe(400);
       expect(err.chatId).toBe(undefined);
-      expect(err.response).toBe(undefined);
+      expect(err.response).toBe("{}");
       expect(err.migrateToChatId).toBe(0);
       expect(err.retryAfter).toBe(0);
       expect(err.url).toBe("");
@@ -51,7 +51,7 @@ describe("tgerror", () => {
       expect(err.message).toBe(`ETELEGRAM ${msg}`);
       expect(err.code).toBe(0);
       expect(err.chatId).toBe(chatId);
-      expect(err.response).toBe(undefined);
+      expect(err.response).toBe("{}");
       expect(err.migrateToChatId).toBe(0);
       expect(err.retryAfter).toBe(0);
       expect(err.url).toBe("");
@@ -67,7 +67,7 @@ describe("tgerror", () => {
       expect(err.message).toBe(`ETELEGRAM ${msg}`);
       expect(err.code).toBe(0);
       expect(err.chatId).toBe(undefined);
-      expect(err.response).toBe(undefined);
+      expect(err.response).toBe("{}");
       expect(err.migrateToChatId).toBe(0);
       expect(err.retryAfter).toBe(retry);
       expect(err.url).toBe("");
@@ -83,7 +83,7 @@ describe("tgerror", () => {
       expect(err.message).toBe(`ETELEGRAM ${msg}`);
       expect(err.code).toBe(0);
       expect(err.chatId).toBe(undefined);
-      expect(err.response).toBe(undefined);
+      expect(err.response).toBe("{}");
       expect(err.migrateToChatId).toBe(chatId);
       expect(err.retryAfter).toBe(0);
       expect(err.url).toBe("");
@@ -99,7 +99,7 @@ describe("tgerror", () => {
       expect(err.message).toBe(`ETELEGRAM ${msg}`);
       expect(err.code).toBe(0);
       expect(err.chatId).toBe(undefined);
-      expect(err.response).toBe(undefined);
+      expect(err.response).toBe("{}");
       expect(err.migrateToChatId).toBe(0);
       expect(err.retryAfter).toBe(0);
       expect(err.url).toBe(url);
@@ -116,7 +116,7 @@ describe("tgerror", () => {
       expect(err.message).toBe(`ETELEGRAM ${msg}`);
       expect(err.code).toBe(0);
       expect(err.chatId).toBe(undefined);
-      expect(err.response).toBe(undefined);
+      expect(err.response).toBe("{}");
       expect(err.migrateToChatId).toBe(0);
       expect(err.retryAfter).toBe(0);
       expect(err.url).toBe(`http://google.com/${SANITIZE_CHARACTER}/sendMessage`);
@@ -130,12 +130,12 @@ describe("tgerror", () => {
         ok: false,
         result: undefined,
       };
-      err.setResponse(response);
+      err.setResponse(JSON.stringify(response));
       expect(err.cause).toBe(errCause);
       expect(err.message).toBe(`ETELEGRAM ${msg}`);
       expect(err.code).toBe(0);
       expect(err.chatId).toBe(undefined);
-      expect(err.response).toBe(response);
+      expect(err.response).toBe(JSON.stringify({ ok: false }));
       expect(err.migrateToChatId).toBe(0);
       expect(err.retryAfter).toBe(0);
       expect(err.url).toBe("");
@@ -149,41 +149,73 @@ describe("tgerror", () => {
 
     it("should return false if the error description is different", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(403).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Forbidden: another reason",
-      });
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Forbidden: another reason",
+        }),
+      );
       expect(isKickedFromSupergroup(tgErr)).toBe(false);
     });
 
     it("should return false if the error code is different", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(400).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Forbidden: bot was kicked from the supergroup chat",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Forbidden: bot was kicked from the supergroup chat",
+        }),
+      );
       expect(isKickedFromSupergroup(tgErr)).toBe(false);
     });
 
     it("should return false if the error is ok", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(403).setResponse({
-        ok: true,
-        result: undefined,
-        description: "Forbidden: bot was kicked from the supergroup chat",
-      });
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: true,
+          result: undefined,
+          description: "Forbidden: bot was kicked from the supergroup chat",
+        }),
+      );
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response is invalid JSON", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(403).setResponse("invalid json");
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response is invalid JSON", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(403).setResponse("invalid json");
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response description is null", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: null,
+        }),
+      );
       expect(isKickedFromSupergroup(tgErr)).toBe(false);
     });
 
     it("should return true if bot was blocked by the user", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(403).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Forbidden: bot was kicked from the supergroup chat",
-      });
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Forbidden: bot was kicked from the supergroup chat",
+        }),
+      );
       expect(isKickedFromSupergroup(tgErr)).toBe(true);
     });
   });
@@ -195,41 +227,67 @@ describe("tgerror", () => {
 
     it("should return false if the error description is different", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(403).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Forbidden: another reason",
-      });
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Forbidden: another reason",
+        }),
+      );
       expect(isBlockedByUser(tgErr)).toBe(false);
     });
 
     it("should return false if the error code is different", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(400).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Forbidden: bot was blocked by the user",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Forbidden: bot was blocked by the user",
+        }),
+      );
       expect(isBlockedByUser(tgErr)).toBe(false);
     });
 
     it("should return false if the error is ok", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(403).setResponse({
-        ok: true,
-        result: undefined,
-        description: "Forbidden: bot was blocked by the user",
-      });
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: true,
+          result: undefined,
+          description: "Forbidden: bot was blocked by the user",
+        }),
+      );
       expect(isBlockedByUser(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response is invalid JSON", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(403).setResponse("invalid json");
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response description is null", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: null,
+        }),
+      );
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
     });
 
     it("should return true if bot was blocked by the user", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(403).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Forbidden: bot was blocked by the user",
-      });
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Forbidden: bot was blocked by the user",
+        }),
+      );
       expect(isBlockedByUser(tgErr)).toBe(true);
     });
   });
@@ -241,41 +299,67 @@ describe("tgerror", () => {
 
     it("should return false if the error description is different", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(400).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: another reason",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Bad Request: another reason",
+        }),
+      );
       expect(hasNoRightsToSendMessage(tgErr)).toBe(false);
     });
 
     it("should return false if the error code is different", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(403).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: not enough rights to send text messages to the chat",
-      });
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Bad Request: not enough rights to send text messages to the chat",
+        }),
+      );
       expect(hasNoRightsToSendMessage(tgErr)).toBe(false);
     });
 
     it("should return false if the error is ok", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(400).setResponse({
-        ok: true,
-        result: undefined,
-        description: "Bad Request: not enough rights to send text messages to the chat",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: true,
+          result: undefined,
+          description: "Bad Request: not enough rights to send text messages to the chat",
+        }),
+      );
       expect(hasNoRightsToSendMessage(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response is invalid JSON", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(400).setResponse("invalid json");
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response description is null", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: null,
+        }),
+      );
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
     });
 
     it("should return true if bot was blocked by the user", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(400).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: not enough rights to send text messages to the chat",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Bad Request: not enough rights to send text messages to the chat",
+        }),
+      );
       expect(hasNoRightsToSendMessage(tgErr)).toBe(true);
     });
   });
@@ -287,44 +371,70 @@ describe("tgerror", () => {
 
     it("should return false if the error description is different", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(400).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: another reason",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Bad Request: another reason",
+        }),
+      );
       expect(isMessageNotModified(tgErr)).toBe(false);
     });
 
     it("should return false if the error code is different", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(403).setResponse({
-        ok: false,
-        result: undefined,
-        description:
-          "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
-      });
+      tgErr.setErrorCode(403).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description:
+            "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
+        }),
+      );
       expect(isMessageNotModified(tgErr)).toBe(false);
     });
 
     it("should return false if the error is ok", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(400).setResponse({
-        ok: true,
-        result: undefined,
-        description:
-          "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: true,
+          result: undefined,
+          description:
+            "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
+        }),
+      );
       expect(isMessageNotModified(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response is invalid JSON", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(400).setResponse("invalid json");
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
+    });
+
+    it("should return false if the response description is null", () => {
+      const tgErr = new TgError(new Error("ooops"), "ooops");
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: null,
+        }),
+      );
+      expect(isKickedFromSupergroup(tgErr)).toBe(false);
     });
 
     it("should return true if the message is not modified", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
-      tgErr.setErrorCode(400).setResponse({
-        ok: false,
-        result: undefined,
-        description:
-          "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description:
+            "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
+        }),
+      );
       expect(isMessageNotModified(tgErr)).toBe(true);
     });
   });

--- a/src/telegram/api/tgerror.ts
+++ b/src/telegram/api/tgerror.ts
@@ -6,7 +6,7 @@ import type { ChatId } from "./core.js";
 export class TgError extends Error {
   public code = 0;
   public chatId?: ChatId;
-  public response?: TgCore<void>;
+  public response = "{}";
   public migrateToChatId = 0;
   public retryAfter = 0;
   public url = "";
@@ -20,7 +20,7 @@ export class TgError extends Error {
     return this;
   }
 
-  public setResponse(response?: TgCore<void>): this {
+  public setResponse(response: string): this {
     this.response = response;
     return this;
   }
@@ -52,10 +52,16 @@ const assertErrCondition = (err: unknown, status: number, text: string): boolean
   if (!(err instanceof TgError)) {
     return false;
   }
-  const isErr = !err?.response?.ok;
-  const isStatusExpected = err?.code === status;
-  const isTextExpected = err?.response?.description?.toLowerCase() === text.toLowerCase();
-  return isErr && isStatusExpected && isTextExpected;
+
+  try {
+    const isStatusExpected = err.code === status;
+    const response = JSON.parse(err.response) as TgCore<void>;
+    const isErr = !response.ok;
+    const isTextExpected = response.description?.toLowerCase() === text.toLowerCase();
+    return isErr && isStatusExpected && isTextExpected;
+  } catch {
+    return false;
+  }
 };
 
 export const hasNoRightsToSendMessage = (err: unknown): boolean => {

--- a/src/telegram/reflector.spec.ts
+++ b/src/telegram/reflector.spec.ts
@@ -13,11 +13,16 @@ describe("initTgReflector", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
       const chatId = asChatId__test(1213455);
 
-      tgErr.setErrorCode(400).setChatId(chatId).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: not enough rights to send text messages to the chat",
-      });
+      tgErr
+        .setErrorCode(400)
+        .setChatId(chatId)
+        .setResponse(
+          JSON.stringify({
+            ok: false,
+            result: undefined,
+            description: "Bad Request: not enough rights to send text messages to the chat",
+          }),
+        );
       await reflect(tgErr);
       expect(leaveChat).toHaveBeenCalledTimes(1);
       expect(leaveChat).toHaveBeenCalledWith(chatId);
@@ -29,11 +34,13 @@ describe("initTgReflector", () => {
       const reflect = initTgReflector({ leaveChat });
       const tgErr = new TgError(new Error("ooops"), "ooops");
 
-      tgErr.setErrorCode(400).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: not enough rights to send text messages to the chat",
-      });
+      tgErr.setErrorCode(400).setResponse(
+        JSON.stringify({
+          ok: false,
+          result: undefined,
+          description: "Bad Request: not enough rights to send text messages to the chat",
+        }),
+      );
 
       await reflect(tgErr);
       expect(leaveChat).not.toHaveBeenCalled();
@@ -45,11 +52,16 @@ describe("initTgReflector", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
       const chatId = asChatId__test(21313);
 
-      tgErr.setErrorCode(400).setChatId(chatId).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: another error",
-      });
+      tgErr
+        .setErrorCode(400)
+        .setChatId(chatId)
+        .setResponse(
+          JSON.stringify({
+            ok: false,
+            result: undefined,
+            description: "Bad Request: another error",
+          }),
+        );
 
       await reflect(tgErr);
       expect(leaveChat).not.toHaveBeenCalled();
@@ -65,11 +77,16 @@ describe("initTgReflector", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
       const chatId = asChatId__test(1213455);
 
-      tgErr.setErrorCode(400).setChatId(chatId).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: not enough rights to send text messages to the chat",
-      });
+      tgErr
+        .setErrorCode(400)
+        .setChatId(chatId)
+        .setResponse(
+          JSON.stringify({
+            ok: false,
+            result: undefined,
+            description: "Bad Request: not enough rights to send text messages to the chat",
+          }),
+        );
 
       await reflect(tgErr);
       expect(leaveChat).toHaveBeenCalledTimes(1);
@@ -82,11 +99,16 @@ describe("initTgReflector", () => {
       const tgErr = new TgError(new Error("ooops"), "ooops");
       const chatId = asChatId__test(1213455);
 
-      tgErr.setErrorCode(400).setChatId(chatId).setResponse({
-        ok: false,
-        result: undefined,
-        description: "Bad Request: not enough rights to send text messages to the chat",
-      });
+      tgErr
+        .setErrorCode(400)
+        .setChatId(chatId)
+        .setResponse(
+          JSON.stringify({
+            ok: false,
+            result: undefined,
+            description: "Bad Request: not enough rights to send text messages to the chat",
+          }),
+        );
 
       await reflect(tgErr);
       expect(leaveChat).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Avoid `response: [Object]` in Sentry by unifying the error response property with other errors in the applciation. We always save the response STRING and parse the json on demand when needed