### PR TITLE
fix(memory): openAsBlob is holding the memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "pnpm run ts start ts",
     "dev": "pnpm run ts dev ts",
     "cluster": "pnpm run ts cluster ts",
-    "js": "node --env-file=.env --experimental-loader newrelic/esm-loader.mjs -r newrelic dist/src/scripts/run.js",
+    "js": "node --max-old-space-size=768 --env-file=.env --experimental-loader newrelic/esm-loader.mjs -r newrelic dist/src/scripts/run.js",
     "start:js": "pnpm run js start js",
     "dev:js": "pnpm run js dev js",
     "cluster:js": "npm run js cluster js",

--- a/src/ffmpeg/index.ts
+++ b/src/ffmpeg/index.ts
@@ -4,7 +4,7 @@ import ffmpeg from "fluent-ffmpeg";
 import { Logger } from "../logger/index.js";
 import { deleteFileIfExists, saveStreamToFile } from "../files/index.js";
 import { API_TIMEOUT_MS, wavSampleRate } from "../const.js";
-import { openAsBlob } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { getResponseErrorData } from "../server/error.js";
 
 const logger = new Logger("media-to-wav");
@@ -100,6 +100,7 @@ export const getAudioBlob = async (
   shouldConvertToWav = true,
 ): Promise<[Blob, string]> => {
   const filePath = await getAudioFilePath(fileLink, isLocalFile, shouldConvertToWav);
-  const fileBlob = await openAsBlob(filePath);
+  const fileBuffer = await readFile(filePath);
+  const fileBlob = new Blob([fileBuffer]);
   return [fileBlob, filePath];
 };


### PR DESCRIPTION
openAsBlob does not always release the file handler, hence the Buffer stays in memory. We are attempting to replace it with readFile - so read the whole file into memory, but then release the whole thing and this will allow us to keep stable MEM consumption