### PR TITLE
fix(perf): Perf nit-picks

### DIFF
--- a/src/analytics/amplitude/index.ts
+++ b/src/analytics/amplitude/index.ts
@@ -1,4 +1,4 @@
-import { init as initAmplitude } from "@amplitude/node";
+import { init as initAmplitude, type NodeClient } from "@amplitude/node";
 import { customAlphabet } from "nanoid";
 import type { AnalyticsEventExt } from "../ga/types.js";
 import { Logger } from "../../logger/index.js";
@@ -7,6 +7,17 @@ import { isDevelopment } from "../../common/environment.js";
 import type { ChatId } from "../../telegram/api/core.js";
 
 const logger = new Logger("analytics:amplitude");
+
+let LOG_EVENT_HANDLER: NodeClient["logEvent"] | undefined;
+
+const getEventHandler = (token: string): NodeClient["logEvent"] => {
+  if (!LOG_EVENT_HANDLER) {
+    const client = initAmplitude(token);
+    LOG_EVENT_HANDLER = client.logEvent.bind(client);
+  }
+
+  return LOG_EVENT_HANDLER;
+};
 
 export const collectEvents = async (
   chatId: ChatId | "system_executor",
@@ -41,11 +52,11 @@ export const collectEvents = async (
      * SessionId, 19 chars max
      */
     const eventSession = isBrokenSessionId ? {} : { session_id: sessionId };
-    const client = initAmplitude(amplitudeToken);
+    const logEvent = getEventHandler(amplitudeToken);
 
     await Promise.all(
       events.map((event) =>
-        client.logEvent({
+        logEvent({
           event_type: event.name,
           user_id: String(chatId),
           language: event.params.language,

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -16,7 +16,7 @@ const getMemoryUsageMb = (): NodeJS.MemoryUsage => {
     heapUsed: getMb(stat.heapUsed),
     external: getMb(stat.external),
     rss: getMb(stat.rss),
-    arrayBuffers: stat.arrayBuffers,
+    arrayBuffers: getMb(stat.arrayBuffers),
   };
 };
 
@@ -27,38 +27,38 @@ export const getMB = (mb: number): number => {
 };
 
 export const printCurrentMemoryStat = async (limit?: number, offset = 15): Promise<number> => {
-  const stat = getMemoryUsageMb();
-  const line = `Current usage [rss=${stat.rss}Mb] [heapTotal=${stat.heapTotal}Mb] [heapUsed=${stat.heapUsed}Mb]`;
+  const { rss, heapTotal, heapUsed, arrayBuffers, external } = getMemoryUsageMb();
+  const line = `Current usage [rss=${rss}Mb] [heapTotal=${heapTotal}Mb] [heapUsed=${heapUsed}Mb] [external=${external}Mb] [arrayBuffers=${arrayBuffers}Mb]`;
   if (!limit) {
     logger.info(line);
-    return stat.rss;
+    return rss;
   }
 
   const fullStat = 100;
   const dangerStat = fullStat - offset;
   const warningStat = dangerStat - offset;
-  const statDiff = (stat.rss * fullStat) / limit;
+  const statDiff = (rss * fullStat) / limit;
 
   if (statDiff > fullStat) {
     logger.error(
       `The process exceeds memory limit ${limit}Mb! ${line}`,
       new Error("The process exceeds memory limit"),
     );
-    return stat.rss;
+    return rss;
   }
 
   if (statDiff > dangerStat) {
     logger.error(line, new Error(line));
-    return stat.rss;
+    return rss;
   }
 
   if (statDiff > warningStat) {
     logger.warn(line, {}, true);
-    return stat.rss;
+    return rss;
   }
 
   logger.info(line);
-  return stat.rss;
+  return rss;
 };
 
 export const sendMemoryStatAnalytics = async (

--- a/src/telegram/api/tgMTProtoApi.ts
+++ b/src/telegram/api/tgMTProtoApi.ts
@@ -17,6 +17,7 @@ export const getMTProtoApi = (appId: number, appHash: string, apiToken: string):
     apiId: appId,
     apiHash: appHash,
     storage: "file-temp/client.session",
+    disableUpdates: true,
   });
 
   return {


### PR DESCRIPTION
- fix(mtproto): Do not subscribe updates [b0598d3](https://github.com/n0th1ng-else/voice-to-text-bot/pull/596/commits/b0598d37d2d9c1f6e9ed4e4ee9193463a42c05c0)

We only use MT-Proto integration for downloading files, nothing more. Hence we set the disableUpdates: true so it does not initialize the subscribers for the events

- fix(server): Print missing externals and arrayBuffers mem consumption

The memory daemon does not print arrayBuffers and externals consumption now. We are adding it into the logged message

- fix(analytics): Amplitude client singleton [10fb905](https://github.com/n0th1ng-else/voice-to-text-bot/pull/596/commits/10fb90566e1f5e841fac859e51d376c9ffcb7d8d)

Instead of re-creating the Amplitude client again and again on each event, we create a single instance of the client and save it. Now on every event we re-use the existing client