### PR TITLE
fix(memory): Send voice file as Buffer with manual multipart body

### DIFF
--- a/src/ffmpeg/index.ts
+++ b/src/ffmpeg/index.ts
@@ -2,7 +2,7 @@ import { Readable } from "node:stream";
 import ffmpegBinPath from "ffmpeg-static";
 import ffmpeg from "fluent-ffmpeg";
 import { Logger } from "../logger/index.js";
-import { deleteFileIfExists, saveStreamToFile } from "../files/index.js";
+import { deleteFileIfExists, readFileIntoBuffer, saveStreamToFile } from "../files/index.js";
 import { API_TIMEOUT_MS, wavSampleRate } from "../const.js";
 import { openAsBlob } from "node:fs";
 import { getResponseErrorData } from "../server/error.js";
@@ -102,4 +102,21 @@ export const getAudioBlob = async (
   const filePath = await getAudioFilePath(fileLink, isLocalFile, shouldConvertToWav);
   const fileBlob = await openAsBlob(filePath);
   return [fileBlob, filePath];
+};
+
+/**
+ * Reads the audio file into a plain Buffer instead of a Blob.
+ * Blob data lives in the internal native blob store that is not visible in
+ * process.memoryUsage() and is only released on GC finalization, which leads
+ * to unbounded RSS growth. Buffers are tracked (external/arrayBuffers) and
+ * released deterministically.
+ */
+export const getAudioBuffer = async (
+  fileLink: string,
+  isLocalFile: boolean,
+  shouldConvertToWav = true,
+): Promise<[Buffer, string]> => {
+  const filePath = await getAudioFilePath(fileLink, isLocalFile, shouldConvertToWav);
+  const fileBuffer = await readFileIntoBuffer(filePath);
+  return [fileBuffer, filePath];
 };

--- a/src/recognition/apiBase.ts
+++ b/src/recognition/apiBase.ts
@@ -1,6 +1,6 @@
 import { type ConverterMeta, type LanguageCode, VoiceConverter } from "./types.js";
 import { Logger } from "../logger/index.js";
-import { getAudioBlob } from "../ffmpeg/index.js";
+import { getAudioBuffer } from "../ffmpeg/index.js";
 import { deleteFileIfExists } from "../files/index.js";
 import { getResponseErrorData } from "../server/error.js";
 
@@ -55,13 +55,13 @@ export abstract class APIVoiceConverter<Res> extends VoiceConverter {
   ): Promise<string> {
     const name = `${logData.fileId}.ogg`;
     logger.info(`${logData.prefix} Starting process for ${Logger.y(name)}`);
-    const [fileBlob, filePath] = await getAudioBlob(fileLink, isLocalFile, !this.useRawFile);
+    const [fileBuffer, filePath] = await getAudioBuffer(fileLink, isLocalFile, !this.useRawFile);
     logger.info(`${logData.prefix} Start converting ${Logger.y(name)}`);
 
     try {
       const result = await this.recognise(
         {
-          data: fileBlob,
+          data: fileBuffer,
           name,
           duration: fileDuration,
         },
@@ -76,7 +76,7 @@ export abstract class APIVoiceConverter<Res> extends VoiceConverter {
 
   protected abstract recognise(
     file: {
-      data: Blob;
+      data: Buffer;
       name: string;
       duration: number;
     },

--- a/src/recognition/apiSelfHost.ts
+++ b/src/recognition/apiSelfHost.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import type { LanguageCode } from "./types.js";
 import { APIVoiceConverter } from "./apiBase.js";
 import { APIVoiceConverterError } from "./apiSelfHostError.js";
@@ -28,7 +29,7 @@ export class ApiSelfHost extends APIVoiceConverter<ApiResponse> {
 
   protected async recognise(
     file: {
-      data: Blob;
+      data: Buffer;
       name: string;
       duration: number;
     },
@@ -41,21 +42,32 @@ export class ApiSelfHost extends APIVoiceConverter<ApiResponse> {
     try {
       const language = convertLanguageCodeToISO(lang);
 
-      const form = new FormData();
-      form.append("language", language);
-
       const fileName =
         !this.useRawFile && !file.name.endsWith(".wav") ? `${file.name}.wav` : file.name;
-      form.append("file", file.data, fileName);
+
+      // Build the multipart body manually from Buffers instead of FormData+Blob.
+      // Blob data is held in the internal native blob store which is invisible
+      // to process.memoryUsage() and only freed on GC finalization (unbounded
+      // RSS growth), while Buffers are tracked and released deterministically.
+      const boundary = `----VoiceToTextFormBoundary${nanoid()}`;
+      const head = Buffer.from(
+        `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="language"\r\n\r\n` +
+          `${language}\r\n` +
+          `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="file"; filename="${fileName}"\r\n` +
+          `Content-Type: application/octet-stream\r\n\r\n`,
+      );
+      const tail = Buffer.from(`\r\n--${boundary}--\r\n`);
+      const body = Buffer.concat([head, file.data, tail]);
 
       const response = await fetch(url, {
         method: "POST",
-        headers: this.apiToken
-          ? {
-              Authorization: `Bearer ${this.apiToken}`,
-            }
-          : {},
-        body: form,
+        headers: {
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
+          ...(this.apiToken ? { Authorization: `Bearer ${this.apiToken}` } : {}),
+        },
+        body,
         signal: AbortSignal.timeout(API_TIMEOUT_MS),
       });
 


### PR DESCRIPTION
Both openAsBlob (#593) and readFile+new Blob (#589) route the file bytes through the internal native blob store, which is invisible to process.memoryUsage() and only freed on GC finalization - matching the untracked RSS growth we observe (rss grows while heapUsed/external stay flat). Remove Blob and FormData from the self-host upload path entirely: read the file into a plain Buffer and build the multipart/form-data body manually with Buffer.concat. Buffers are tracked in external/arrayBuffers and released deterministically.