### PR TITLE
fix(api): Fix deleting keyboard

### DIFF
--- a/e2e/requests/telegram.ts
+++ b/e2e/requests/telegram.ts
@@ -299,7 +299,7 @@ export const mockTgReceiveCallbackMessage = (
           });
         });
       } else {
-        expect(answer.reply_markup).toEqual({ remove_keyboard: true });
+        expect(answer.reply_markup).not.toBeDefined();
       }
       resolve();
       return makeTelegramResponse<TgMessage>(

--- a/src/telegram/api/groups/chats/chats-api.ts
+++ b/src/telegram/api/groups/chats/chats-api.ts
@@ -70,10 +70,6 @@ export class TelegramChatsApi {
       data.reply_markup = {
         inline_keyboard: options.buttons,
       };
-    } else {
-      data.reply_markup = {
-        remove_keyboard: true,
-      };
     }
 
     return this.client.requestValidate("editMessageText", TgMessageSchema, data, chatId);


### PR DESCRIPTION
The bot token was taken and we lost control for ~24 hours.

The bot added two things
- keyboard
- pinned message

in #599 we fixed keyboard, but the editMessage command is failing. It is not needed so we are reverting the editMessage part